### PR TITLE
Modifications for Long Training

### DIFF
--- a/gns/train.py
+++ b/gns/train.py
@@ -5,6 +5,8 @@ import numpy as np
 import os
 import torch
 import pickle
+import glob
+import re
 
 import tensorflow as tf
 import tensorflow_datasets as tfds
@@ -27,8 +29,8 @@ flags.DEFINE_float('noise_std', 6.7e-4, help='The std deviation of the noise.')
 flags.DEFINE_string('data_path', None, help='The dataset directory.')
 flags.DEFINE_string('model_path', 'models/', help=('The path for saving checkpoints of the model.'))
 flags.DEFINE_string('output_path', 'rollouts/', help='The path for saving outputs (e.g. rollouts).')
-flags.DEFINE_string('model_file', None, help=('Model filename (.pt) to resume from.'))
-flags.DEFINE_string('train_state_file', 'train_state.pt', help=('Train state filename (.pt).'))
+flags.DEFINE_string('model_file', None, help=('Model filename (.pt) to resume from. Can also use "latest" to default to newest file.'))
+flags.DEFINE_string('train_state_file', 'train_state.pt', help=('Train state filename (.pt) to resume from. Can also use "latest" to default to newest file.'))
 
 flags.DEFINE_integer('ntraining_steps', int(2E7), help='Number of training steps.')
 flags.DEFINE_integer('nsave_steps', int(5000), help='Number of steps at which to save the model.')
@@ -37,6 +39,8 @@ flags.DEFINE_integer('nsave_steps', int(5000), help='Number of steps at which to
 flags.DEFINE_float('lr_init', 1e-4, help='Initial learning rate.')
 flags.DEFINE_float('lr_decay', 0.1, help='Learning rate decay.')
 flags.DEFINE_integer('lr_decay_steps', int(5e6), help='Learning rate decay steps.')
+
+flag.DEFINE_integer("cuda_device_number", None, help="CUDA device (zero indexed), default is None so default CUDA device will be used.")
 
 FLAGS = flags.FLAGS
 
@@ -47,6 +51,8 @@ NUM_PARTICLE_TYPES = 9
 KINEMATIC_PARTICLE_ID = 3
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+if FLAGS.cuda_device_number is not None and torch.cuda.is_available():
+  device = torch.device(f'cuda:{int(FLAGS.cuda_device_number)}')
 
 def prepare_inputs(tensor_dict):
   """Prepares a single stack of inputs by calculating inputs and targets.
@@ -333,6 +339,20 @@ def train(
 
   # If model_path does exist and model_file and train_state_file exist continue training.
   if FLAGS.model_file is not None:
+
+    if FLAGS.model_file == "latest" and FLAGS.train_state_file == "latest":
+      # find the latest model, assumes model and train_state files are in step.
+      fnames = glob.glob(f"{model_path}*model*pt")
+      max_model_number = 0
+      expr = re.compile(".*model-(\d+).pt")
+      for fname in fnames:
+        model_num = int(expr.search(fname).groups()[0])
+        if model_num > max_model_number:
+          max_model_number = model_num
+      # reset names to point to the latest.
+      FLAGS.model_file = f"model-{max_model_number}.pt"
+      FLAGS.train_state_file = f"train_state-{max_model_number}.pt"
+
     if os.path.exists(model_path + FLAGS.model_file) and os.path.exists(model_path + FLAGS.train_state_file):
       # load model
       simulator.load(model_path + FLAGS.model_file)


### PR DESCRIPTION
# In this PR

- ✨ Allow user to specify the gpu of choice. This will allow two embarissingly parallel models to be trained at the same time on LS6 (one per a100 GPU).
- ✨ Allow user to specify `latest` instead of the specific model name. This will allow multiple jobs to be queued via slurm for long rums and avoids needing to manually update the restart file name and relaunch the training every 48 hours.
- 🔨 Make `device` non-global, needed to allow the manual selection of the device via command line argument.