### PR TITLE
Add GPU specification and refactor FLAG conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,151 @@ In mesh-based domain, the renderer writes `.gif` animation.
 ![Fluid flow rollout](docs/img/meshnet.gif)
 > Meshnet GNS prediction of cylinder flow after training for 1 million steps.
 
+
+## Command line arguments details
+<details>
+<summary>`train.py` in GNS (particulate domain) </summary>
+
+**mode (Enum)** 
+
+This flag is used to set the operation mode for the script. It can take one of three values; 'train', 'valid', or 'rollout'.
+
+**batch_size (Integer)**
+
+Batch size for training.
+
+**noise_std (Float)** 
+
+Standard deviation of the noise when training.
+
+**data_path (String)** 
+
+Specifies the directory path where the dataset is located. 
+The dataset is expected to be in a specific format (e.g., .npz files).
+It should contain `metadata.json`.
+If `--mode` is training, the directory should contain `train.npz`.
+If `--mode` is testing (rollout), the directory should contain `test.npz`.
+If `--mode` is valid, the directory should contain `valid.npz`.
+
+**model_path (String)** 
+
+The directory path where the trained model checkpoints are saved during training or loaded from during validation/rollout.
+
+**output_path (String)** 
+
+Defines the directory where the outputs (e.g., rollouts) are saved, 
+when the `--mode` is set to rollout.
+This is particularly relevant in the rollout mode where the predictions of the model are stored.
+
+**output_filename (String)** 
+
+Base filename to use when saving outputs during rollout.
+Default is "rollout", and the output will be saved as `rollout.pkl` in `output_path`. 
+It is not intended to include the file extension.
+
+**model_file (String)** 
+
+The filename of the model checkpoint to load for validation or rollout (e.g., model-10000.pt). 
+It supports a special value "latest" to automatically select the newest checkpoint file. 
+This flexibility facilitates the evaluation of models at different stages of training.
+
+**train_state_file (String)** 
+
+Similar to model_file, but for loading the training state (e.g., optimizer state).
+It supports a special value "latest" to automatically select the newest checkpoint file. 
+(e.g., training_state-10000.pt)
+
+**ntraining_steps (Integer)** 
+
+The total number of training steps to execute before stopping.
+
+**nsave_steps (Integer)** 
+
+Interval at which the model and training state are saved.
+
+**lr_init (Float)** 
+
+Initial learning rate.
+
+**lr_decay (Float)** 
+
+How much the learning rate should decay over time.
+
+**lr_decay_steps (Integer)** 
+
+Steps at which learning rate should decay.
+
+**cuda_device_number (Integer)** 
+
+Base CUDA device (zero indexed).
+Default is None so default CUDA device will be used.
+
+**n_gpus (Integer)** 
+
+Number of GPUs to use for training.
+</details>
+
+
+
+<details>
+<summary>`train.py` in MeshNet (mesh-based domain) </summary>
+
+**mode (String)**
+
+This flag is used to set the operation mode for the script. It can take one of three values; 'train', 'valid', or 'rollout'.
+
+**batch_size (Integer)** 
+
+Batch size for training.
+
+**data_path (String)**
+
+Specifies the directory path where the dataset is located. 
+The dataset is expected to be in a specific format (e.g., .npz files).
+If `--mode` is training, the directory should contain `train.npz`.
+If `--mode` is testing (rollout), the directory should contain `test.npz`.
+If `--mode` is valid, the directory should contain `valid.npz`.
+
+**model_path (String)** 
+
+The directory path where the trained model checkpoints are saved during training or loaded from during validation/rollout.
+
+**output_path (String)**
+
+Defines the directory where the outputs (e.g., rollouts) are saved, 
+when the `--mode` is set to rollout.
+This is particularly relevant in the rollout mode where the predictions of the model are stored.
+
+**model_file (String)**
+
+The filename of the model checkpoint to load for validation or rollout (e.g., model-10000.pt). 
+It supports a special value "latest" to automatically select the newest checkpoint file. 
+This flexibility facilitates the evaluation of models at different stages of training.
+
+**train_state_file (String)**
+
+Similar to model_file, but for loading the training state (e.g., optimizer state).
+It supports a special value "latest" to automatically select the newest checkpoint file. 
+(e.g., training_state-10000.pt)
+
+**cuda_device_number (Integer)**
+
+Allows specifying a particular CUDA device for training or evaluation, enabling the use of specific GPUs in multi-GPU setups.
+
+**rollout_filename (String)**
+
+Base name for saving rollout files. The actual filenames will append an index to this base name.
+
+**ntraining_steps (Integer)**
+
+The total number of training steps to execute before stopping.
+
+**nsave_steps (Integer)**
+
+Interval at which the model and training state are saved.
+
+</details>
+
 ## Datasets
 ### Particulate domain:
 We use the numpy `.npz` format for storing positional data for GNS training.  The `.npz` format includes a list of tuples of arbitrary length where each tuple corresponds to a differenet training trajectory and is of the form `(position, particle_type)`.  The data loader provides `INPUT_SEQUENCE_LENGTH` positions, set equal to six by default, to provide the GNS with the last `INPUT_SEQUENCE_LENGTH` minus one positions as input to predict the position at the next time step.  The `position` is a 3-D tensor of shape `(n_time_steps, n_particles, n_dimensions)` and `particle_type` is a 1-D tensor of shape `(n_particles)`.  
@@ -172,3 +317,4 @@ Kumar, K., & Vantassel, J. (2023). GNS: A generalizable Graph Neural Network-bas
 #### Dataset
 * Vantassel, Joseph; Kumar, Krishna (2022) “Graph Network Simulator Datasets.” DesignSafe-CI. https://doi.org/10.17603/ds2-0phb-dg64 v1 
 * Kumar, K., Y. Choi. (2023) "Cylinder flow with graph neural network-based simulator." DesignSafe-CI. https://doi.org/10.17603/ds2-fzg7-1719
+

--- a/gns/reading_utils.py
+++ b/gns/reading_utils.py
@@ -25,3 +25,10 @@ def read_metadata(data_path: str,
       metadata = json.loads(fp.read())
 
   return metadata
+
+def flags_to_dict(FLAGS):
+  flags_dict = {}
+  for name in FLAGS:
+    flag_value = FLAGS[name].value
+    flags_dict[name] = flag_value
+  return flags_dict

--- a/gns/train.py
+++ b/gns/train.py
@@ -42,6 +42,7 @@ flags.DEFINE_float('lr_decay', 0.1, help='Learning rate decay.')
 flags.DEFINE_integer('lr_decay_steps', int(5e6), help='Learning rate decay steps.')
 
 flags.DEFINE_integer("cuda_device_number", None, help="CUDA device (zero indexed), default is None so default CUDA device will be used.")
+flags.DEFINE_integer("n_gpus", 1, help="The number of GPUs to utilize for training")
 
 FLAGS = flags.FLAGS
 
@@ -460,18 +461,7 @@ def main(_):
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = "29500"
 
-  myflags = {}
-  myflags["data_path"] = FLAGS.data_path
-  myflags["noise_std"] = FLAGS.noise_std
-  myflags["lr_init"] = FLAGS.lr_init
-  myflags["lr_decay"] = FLAGS.lr_decay
-  myflags["lr_decay_steps"] = FLAGS.lr_decay_steps
-  myflags["batch_size"] = FLAGS.batch_size
-  myflags["ntraining_steps"] = FLAGS.ntraining_steps
-  myflags["nsave_steps"] = FLAGS.nsave_steps
-  myflags["model_file"] = FLAGS.model_file
-  myflags["model_path"] = FLAGS.model_path
-  myflags["train_state_file"] = FLAGS.train_state_file
+  myflags = reading_utils.flags_to_dict(FLAGS)
 
   if FLAGS.mode == 'train':
     # If model_path does not exist create new directory.
@@ -480,8 +470,24 @@ def main(_):
 
     # Train on gpu 
     if device == torch.device('cuda'):
-      world_size = torch.cuda.device_count()
-      print(f"world_size = {world_size}")
+      available_gpus = torch.cuda.device_count()
+      print(f"Available GPUs = {available_gpus}")
+
+      # Set number of GPUs to use and print status
+      if FLAGS.n_gpus is None:
+        world_size = available_gpus
+        print(f"Using all available GPUs: {world_size}/{available_gpus}")
+      else:
+        # Check if the specified number of GPUs exceeds the available GPUs
+        if FLAGS.n_gpus > available_gpus:
+          world_size = available_gpus
+          print(f"Warning: The number of GPUs specified ({FLAGS.n_gpus}) exceeds the available GPUs ({available_gpus}")
+          print(f"Using all available GPUs: {world_size}/{available_gpus}")
+        else:
+          world_size = FLAGS.n_gpus
+        print(f"Using {world_size}/{available_gpus} GPUs")
+
+      # Spawn training to GPUs
       distribute.spawn_train(train, myflags, world_size, device)
 
     # Train on cpu  

--- a/gns/train.py
+++ b/gns/train.py
@@ -473,19 +473,16 @@ def main(_):
       available_gpus = torch.cuda.device_count()
       print(f"Available GPUs = {available_gpus}")
 
-      # Set number of GPUs to use and print status
-      if FLAGS.n_gpus is None:
+      # Set the number of GPUs based on availability and the specified number
+      if FLAGS.n_gpus is None or FLAGS.n_gpus > available_gpus:
         world_size = available_gpus
-        print(f"Using all available GPUs: {world_size}/{available_gpus}")
+        if FLAGS.n_gpus is not None:
+          print(f"Warning: The number of GPUs specified ({FLAGS.n_gpus}) exceeds the available GPUs ({available_gpus})")
       else:
-        # Check if the specified number of GPUs exceeds the available GPUs
-        if FLAGS.n_gpus > available_gpus:
-          world_size = available_gpus
-          print(f"Warning: The number of GPUs specified ({FLAGS.n_gpus}) exceeds the available GPUs ({available_gpus}")
-          print(f"Using all available GPUs: {world_size}/{available_gpus}")
-        else:
-          world_size = FLAGS.n_gpus
-        print(f"Using {world_size}/{available_gpus} GPUs")
+        world_size = FLAGS.n_gpus
+
+      # Print the status of GPU usage
+      print(f"Using {world_size}/{available_gpus} GPUs")
 
       # Spawn training to GPUs
       distribute.spawn_train(train, myflags, world_size, device)


### PR DESCRIPTION
**Describe the PR**
* Introduced an option to specify the number of GPUs to use for training. It handles scenarios where a specified number of GPUs is more than what's available. 
* The code now consolidates FLAG values into a dictionary using a utility function by refactoring flag parsing into 'flags_to_dict' function in 'reading_utils.py' for easier and cleaner flag extraction.