### PR TITLE
Logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
             conda install -c conda-forge matplotlib-base -y
             conda install -c conda-forge pyevtk -y
             conda install -c conda-forge pytest -y
+            conda install -c conda-forge tensorboard -y
             pytest test/
             echo "Test paths: ${DATA_PATH} ${MODEL_PATH}"
             ls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,12 @@ jobs:
             echo "Predict rollout"
             ls ./gns-sample/WaterDropSample/models/
             
+      - run: 
+          name: Black check 
+          command: |
+            conda install -c conda-forge black -y
+            black --check .
+
 workflows:
     version: 2
     build:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.swp
 scratch
 log
+**/logs/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Number of GPUs to use for training.
 **tensorboard_log_dir (String)**
 
 Path to log info on training and validation and visualize via tensorboard.
+
 </details>
 
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Default is None so default CUDA device will be used.
 **n_gpus (Integer)** 
 
 Number of GPUs to use for training.
+
+**tensorboard_log_dir (String)**
+
+Path to log info on training and validation and visualize via tensorboard.
 </details>
 
 

--- a/example/inverse_problem/forward.py
+++ b/example/inverse_problem/forward.py
@@ -4,15 +4,15 @@ from tqdm import tqdm
 
 
 def rollout_with_checkpointing(
-        simulator: learned_simulator.LearnedSimulator,
-        initial_positions: torch.tensor,
-        particle_types: torch.tensor,
-        n_particles_per_example: torch.tensor,
-        nsteps: int,
-        checkpoint_interval: int = 1,
-        material_property: torch.tensor = None
+    simulator: learned_simulator.LearnedSimulator,
+    initial_positions: torch.tensor,
+    particle_types: torch.tensor,
+    n_particles_per_example: torch.tensor,
+    nsteps: int,
+    checkpoint_interval: int = 1,
+    material_property: torch.tensor = None,
 ):
-    """ Rollout with gradient checkpointing to reduce memory accumulation over the forward steps during backpropagation.
+    """Rollout with gradient checkpointing to reduce memory accumulation over the forward steps during backpropagation.
     Args:
       simulator: learned_simulator
       initial_positions: initial positions of particles for 6 timesteps with shape=(nparticles, 6, ndims).
@@ -35,14 +35,14 @@ def rollout_with_checkpointing(
                 current_positions,
                 [n_particles_per_example],
                 particle_types,
-                material_property
+                material_property,
             )
         else:
             next_position = simulator.predict_positions(
                 current_positions,
                 [n_particles_per_example],
                 particle_types,
-                material_property
+                material_property,
             )
 
         predictions.append(next_position)
@@ -50,8 +50,7 @@ def rollout_with_checkpointing(
         # Shift `current_positions`, removing the oldest position in the sequence
         # and appending the next position at the end.
         current_positions = torch.cat(
-            [current_positions[:, 1:], next_position[:, None, :]], dim=1)
+            [current_positions[:, 1:], next_position[:, None, :]], dim=1
+        )
 
-    return torch.cat(
-        (initial_positions.permute(1, 0, 2), torch.stack(predictions))
-    )
+    return torch.cat((initial_positions.permute(1, 0, 2), torch.stack(predictions)))

--- a/example/inverse_problem/inverse.py
+++ b/example/inverse_problem/inverse.py
@@ -19,7 +19,9 @@ from gns import train
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--input_file', default="config.toml", type=str, help="Input file path")
+parser.add_argument(
+    "--input_file", default="config.toml", type=str, help="Input file path"
+)
 args = parser.parse_args()
 
 # Open config file
@@ -36,29 +38,31 @@ initial_velocities = inputs["optimization"]["initial_velocities"]
 
 # inputs for ground truth
 ground_truth_npz = inputs["ground_truth"]["ground_truth_npz"]
-ground_truth_mpm_inputfile = inputs["ground_truth"]['ground_truth_mpm_inputfile']
+ground_truth_mpm_inputfile = inputs["ground_truth"]["ground_truth_mpm_inputfile"]
 
 # inputs for forward simulator
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 noise_std = 6.7e-4  # hyperparameter used to train GNS.
 NUM_PARTICLE_TYPES = 9
-dt_mpm = inputs["forward_simulator"]['dt_mpm']
-model_path = inputs["forward_simulator"]['model_path']
-model_file = inputs["forward_simulator"]['model_file']
-simulator_metadata_path = inputs["forward_simulator"]['simulator_metadata_path']
-simulator_metadata_file = inputs["forward_simulator"]['simulator_metadata_file']
+dt_mpm = inputs["forward_simulator"]["dt_mpm"]
+model_path = inputs["forward_simulator"]["model_path"]
+model_file = inputs["forward_simulator"]["model_file"]
+simulator_metadata_path = inputs["forward_simulator"]["simulator_metadata_path"]
+simulator_metadata_file = inputs["forward_simulator"]["simulator_metadata_file"]
 
 # inputs for output setup
-output_dir = inputs["output"]['output_dir']
-save_step = inputs["output"]['save_step']
+output_dir = inputs["output"]["output_dir"]
+save_step = inputs["output"]["save_step"]
 
 # resume
-resume = inputs["resume"]['resume']
-resume_epoch = inputs["resume"]['epoch']
+resume = inputs["resume"]["resume"]
+resume_epoch = inputs["resume"]["epoch"]
 
 
 # Load simulator
-metadata = reading_utils.read_metadata(simulator_metadata_path, "rollout", file_name=simulator_metadata_file)
+metadata = reading_utils.read_metadata(
+    simulator_metadata_path, "rollout", file_name=simulator_metadata_file
+)
 simulator = train._get_simulator(metadata, noise_std, noise_std, device)
 if os.path.exists(model_path + model_file):
     simulator.load(model_path + model_file)
@@ -68,22 +72,28 @@ simulator.to(device)
 simulator.eval()
 
 # Get ground truth particle position at the inversion timestep
-mpm_trajectory = [item for _, item in np.load(f"{path}/{ground_truth_npz}", allow_pickle=True).items()]
+mpm_trajectory = [
+    item for _, item in np.load(f"{path}/{ground_truth_npz}", allow_pickle=True).items()
+]
 target_final_positions = torch.tensor(
-    mpm_trajectory[0][0][inverse_timestep_range[0]: inverse_timestep_range[1]], device=device)
+    mpm_trajectory[0][0][inverse_timestep_range[0] : inverse_timestep_range[1]],
+    device=device,
+)
 
 # Get ground truth velocities for each particle group.
 f = open(f"{path}/{ground_truth_mpm_inputfile}")
 mpm_inputs = json.load(f)
-velocity_constraints = mpm_inputs["mesh"]["boundary_conditions"]["particles_velocity_constraints"]
+velocity_constraints = mpm_inputs["mesh"]["boundary_conditions"][
+    "particles_velocity_constraints"
+]
 # Initialize an empty NumPy array with the shape (max_pset_id+1, 2)
-max_pset_id = max(item['pset_id'] for item in velocity_constraints)
+max_pset_id = max(item["pset_id"] for item in velocity_constraints)
 ground_truth_vels = np.zeros((max_pset_id + 1, 2))
 # Fill in the NumPy array with velocity values from data
 for constraint in velocity_constraints:
-    pset_id = constraint['pset_id']
-    dir = constraint['dir']
-    velocity = constraint['velocity']
+    pset_id = constraint["pset_id"]
+    dir = constraint["dir"]
+    velocity = constraint["velocity"]
     ground_truth_vels[pset_id, dir] = velocity
 
 # Get initial position (i.e., p_0) for each particle group
@@ -94,14 +104,13 @@ count = 0
 for filename in particle_files:
     particle_group = torch.tensor(np.loadtxt(filename, skiprows=1))
     particle_groups.append(particle_group)
-    particle_group_idx_range = np.arange(count, count+len(particle_group))
-    count = count+len(particle_group)
+    particle_group_idx_range = np.arange(count, count + len(particle_group))
+    count = count + len(particle_group)
     particle_group_idx_ranges.append(particle_group_idx_range)
 initial_position = torch.concat(particle_groups).to(device)
 
 # Initialize initial velocity (i.e., dot{p}_0)
-initial_velocity_x = torch.tensor(
-    initial_velocities, requires_grad=True, device=device)
+initial_velocity_x = torch.tensor(initial_velocities, requires_grad=True, device=device)
 initial_velocity_x_model = To_Torch_Model_Param(initial_velocity_x)
 
 # Set up the optimizer
@@ -116,37 +125,50 @@ if resume:
     print(f"Resume from the previous state: epoch{resume_epoch}")
     checkpoint = torch.load(f"{output_dir}/optimizer_state-{resume_epoch}.pt")
     start_epoch = checkpoint["epoch"]
-    initial_velocity_x_model.load_state_dict(checkpoint['velocity_x_state_dict'])
-    optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+    initial_velocity_x_model.load_state_dict(checkpoint["velocity_x_state_dict"])
+    optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
 else:
     start_epoch = 0
 initial_velocity_x = initial_velocity_x_model.current_params
 initial_velocity_y = torch.full((len(initial_velocity_x), 1), 0).to(device)
 
 # Start optimization iteration
-for epoch in range(start_epoch+1, nepoch):
+for epoch in range(start_epoch + 1, nepoch):
     start = time.time()
     optimizer.zero_grad()  # Clear previous gradients
 
     # Load data containing X0, and get necessary features.
     # First, get particle type and material property.
     dinit = data_loader.TrajectoriesDataset(path=f"{path}/{ground_truth_npz}")
-    for example_i, features in enumerate(dinit):  # only one item exists in `dint`. No need `for` loop
+    for example_i, features in enumerate(
+        dinit
+    ):  # only one item exists in `dint`. No need `for` loop
         # Obtain features
         if len(features) < 3:
             raise NotImplementedError("Data should include material feature")
         particle_type = features[1].to(device)
         material_property = features[2].to(device)
-        n_particles_per_example = torch.tensor([int(features[3])], dtype=torch.int32).to(device)
+        n_particles_per_example = torch.tensor(
+            [int(features[3])], dtype=torch.int32
+        ).to(device)
 
     # Next, make [p0, p1, ..., p5] using current initial velocity, assuming that velocity is the same for 5 timesteps
     initial_velocity = torch.hstack((initial_velocity_x, initial_velocity_y))
     initial_pos_seq_all_group = []
     for i, particle_group_idx_range in enumerate(particle_group_idx_ranges):
         initial_pos_seq_each_group = [
-            initial_position[particle_group_idx_range] + initial_velocity[i] * dt_mpm * t for t in range(6)]
+            initial_position[particle_group_idx_range]
+            + initial_velocity[i] * dt_mpm * t
+            for t in range(6)
+        ]
         initial_pos_seq_all_group.append(torch.stack(initial_pos_seq_each_group))
-    initial_positions = torch.concat(initial_pos_seq_all_group, axis=1).to(device).permute(1, 0, 2).to(torch.float32).contiguous()
+    initial_positions = (
+        torch.concat(initial_pos_seq_all_group, axis=1)
+        .to(device)
+        .permute(1, 0, 2)
+        .to(torch.float32)
+        .contiguous()
+    )
 
     # print(f"Initial velocities: {initial_velocity.detach().cpu().numpy()}")
 
@@ -156,11 +178,15 @@ for epoch in range(start_epoch+1, nepoch):
         particle_types=particle_type,
         material_property=material_property,
         n_particles_per_example=n_particles_per_example,
-        nsteps=inverse_timestep_range[1] - initial_positions.shape[1] + 1, # exclude initial positions (x0) which we already have
-        checkpoint_interval=checkpoint_interval
+        nsteps=inverse_timestep_range[1]
+        - initial_positions.shape[1]
+        + 1,  # exclude initial positions (x0) which we already have
+        checkpoint_interval=checkpoint_interval,
     )
 
-    inversion_positions = predicted_positions[inverse_timestep_range[0]:inverse_timestep_range[1]]
+    inversion_positions = predicted_positions[
+        inverse_timestep_range[0] : inverse_timestep_range[1]
+    ]
 
     loss = torch.mean((inversion_positions - target_final_positions) ** 2)
     print("Backpropagate...")
@@ -169,13 +195,17 @@ for epoch in range(start_epoch+1, nepoch):
     # Visualize current prediction
     print(f"Epoch {epoch - 1}, Loss {loss.item():.8f}")
     print(f"Initial vel: {initial_velocity.detach().cpu().numpy()}")
-    visualize_final_deposits(predicted_positions=predicted_positions,
-                             target_positions=target_final_positions,
-                             metadata=metadata,
-                             write_path=f"{output_dir}/final_deposit-{epoch - 1}.png")
-    visualize_velocity_profile(predicted_velocities=initial_velocity,
-                               target_velocities=ground_truth_vels,
-                               write_path=f"{output_dir}/vel_profile-{epoch - 1}.png")
+    visualize_final_deposits(
+        predicted_positions=predicted_positions,
+        target_positions=target_final_positions,
+        metadata=metadata,
+        write_path=f"{output_dir}/final_deposit-{epoch - 1}.png",
+    )
+    visualize_velocity_profile(
+        predicted_velocities=initial_velocity,
+        target_velocities=ground_truth_vels,
+        write_path=f"{output_dir}/vel_profile-{epoch - 1}.png",
+    )
 
     # Perform optimization step
     optimizer.step()
@@ -185,37 +215,47 @@ for epoch in range(start_epoch+1, nepoch):
 
     # Save and report optimization status
     if epoch % save_step == 0:
-
         # Make animation at the last epoch
         if epoch == nepoch - 1:
             print(f"Rendering animation at {epoch}...")
             positions_np = np.concatenate(
-                (initial_positions.permute(1, 0, 2).detach().cpu().numpy(),
-                 predicted_positions.detach().cpu().numpy())
+                (
+                    initial_positions.permute(1, 0, 2).detach().cpu().numpy(),
+                    predicted_positions.detach().cpu().numpy(),
+                )
             )
-            make_animation(positions=positions_np,
-                           boundaries=metadata["bounds"],
-                           output=f"{output_dir}/animation-{epoch}.gif",
-                           timestep_stride=5)
+            make_animation(
+                positions=positions_np,
+                boundaries=metadata["bounds"],
+                output=f"{output_dir}/animation-{epoch}.gif",
+                timestep_stride=5,
+            )
 
         # Save history
         current_history = {
             "epoch": epoch,
             "lr": optimizer.state_dict()["param_groups"][0]["lr"],
             "initial_velocity_x": initial_velocity_x.detach().cpu().numpy(),
-            "loss": loss.item()
+            "loss": loss.item(),
         }
 
         # Save optimizer state
-        torch.save({
-            'epoch': epoch,
-            'time_spent': time_for_iteration,
-            'position_state_dict': {
-                "target_positions": mpm_trajectory[0][0],
-                "inversion_positions": predicted_positions.clone().detach().cpu().numpy()
+        torch.save(
+            {
+                "epoch": epoch,
+                "time_spent": time_for_iteration,
+                "position_state_dict": {
+                    "target_positions": mpm_trajectory[0][0],
+                    "inversion_positions": predicted_positions.clone()
+                    .detach()
+                    .cpu()
+                    .numpy(),
+                },
+                "velocity_x_state_dict": To_Torch_Model_Param(
+                    initial_velocity_x
+                ).state_dict(),
+                "optimizer_state_dict": optimizer.state_dict(),
+                "loss": loss,
             },
-            'velocity_x_state_dict': To_Torch_Model_Param(initial_velocity_x).state_dict(),
-            'optimizer_state_dict': optimizer.state_dict(),
-            'loss': loss,
-        }, f"{output_dir}/optimizer_state-{epoch}.pt")
-
+            f"{output_dir}/optimizer_state-{epoch}.pt",
+        )

--- a/example/inverse_problem/utils.py
+++ b/example/inverse_problem/utils.py
@@ -21,24 +21,25 @@ def compute_penalty(original_loss, threshold, alpha):
 
 
 def make_animation(
-        positions, boundaries, output, particle_size=1.0, color="blue", timestep_stride=5):
-
+    positions, boundaries, output, particle_size=1.0, color="blue", timestep_stride=5
+):
     fig, ax = plt.subplots()
 
     def animate(i):
         fig.clear()
         # ax = fig.add_subplot(111, aspect='equal', autoscale_on=False, xlim=xboundary, ylim=yboundary)
-        ax = fig.add_subplot(111, aspect='equal', autoscale_on=False)
+        ax = fig.add_subplot(111, aspect="equal", autoscale_on=False)
         ax.set_aspect("equal")
         ax.set_xlim([boundaries[0][0], boundaries[0][1]])
         ax.set_ylim([boundaries[1][0], boundaries[1][1]])
         ax.scatter(positions[i][:, 0], positions[i][:, 1], s=particle_size, c=color)
-        ax.grid(True, which='both')
+        ax.grid(True, which="both")
 
     ani = animation.FuncAnimation(
-        fig, animate, frames=np.arange(0, len(positions), timestep_stride), interval=10)
+        fig, animate, frames=np.arange(0, len(positions), timestep_stride), interval=10
+    )
 
-    ani.save(output, dpi=100, fps=30, writer='imagemagick')
+    ani.save(output, dpi=100, fps=30, writer="imagemagick")
     print(f"Animation saved to: {output}")
 
 
@@ -49,24 +50,35 @@ class To_Torch_Model_Param(torch.nn.Module):
 
 
 def visualize_final_deposits(
-        predicted_positions: torch.tensor,
-        target_positions: torch.tensor,
-        metadata: dict,
-        write_path: str,
-        friction=None,
+    predicted_positions: torch.tensor,
+    target_positions: torch.tensor,
+    metadata: dict,
+    write_path: str,
+    friction=None,
 ):
-
     fig, ax = plt.subplots()
     inversion_positions_plot = predicted_positions.clone().detach().cpu().numpy()
     target_positions_plot = target_positions.clone().detach().cpu().numpy()
-    ax.scatter(inversion_positions_plot[-1][:, 0],
-               inversion_positions_plot[-1][:, 1], alpha=0.5, s=2.0, c="purple", label="Current")
+    ax.scatter(
+        inversion_positions_plot[-1][:, 0],
+        inversion_positions_plot[-1][:, 1],
+        alpha=0.5,
+        s=2.0,
+        c="purple",
+        label="Current",
+    )
     ax.axvline(x=inversion_positions_plot[-1][:, 0].max(), c="purple")
-    ax.scatter(target_positions_plot[-1][:, 0],
-               target_positions_plot[-1][:, 1], alpha=0.5, s=2.0, c="yellow", label="True")
+    ax.scatter(
+        target_positions_plot[-1][:, 0],
+        target_positions_plot[-1][:, 1],
+        alpha=0.5,
+        s=2.0,
+        c="yellow",
+        label="True",
+    )
     ax.axvline(x=target_positions_plot[-1][:, 0].max(), c="yellow")
-    ax.set_xlim(metadata['bounds'][0])
-    ax.set_ylim(metadata['bounds'][1])
+    ax.set_xlim(metadata["bounds"][0])
+    ax.set_ylim(metadata["bounds"][1])
     ax.set_title(f"{friction}:.5f")
     ax.set_aspect("equal")
     ax.legend()
@@ -75,9 +87,7 @@ def visualize_final_deposits(
 
 
 def visualize_velocity_profile(
-        predicted_velocities: torch.tensor,
-        target_velocities: np.array,
-        write_path
+    predicted_velocities: torch.tensor, target_velocities: np.array, write_path
 ):
     fig, axes = plt.subplots(1, 2)
     n_vels = len(predicted_velocities)
@@ -96,4 +106,3 @@ def visualize_velocity_profile(
     axes[0].set_ylabel("y-velocity (m/s)")
     plt.tight_layout()
     plt.savefig(write_path)
-

--- a/gns/distribute.py
+++ b/gns/distribute.py
@@ -3,18 +3,21 @@ from torch.utils.data.distributed import DistributedSampler
 
 from gns import data_loader
 
+
 def setup(rank, world_size, device):
     """Initializes distributed training.
-    
+
     Args:
         rank (int): Rank of current process.
         world_size (int): Number of processes.
     """
     # Initialize group, blocks until all processes join.
-    torch.distributed.init_process_group(backend="nccl",
-                                         rank=rank,
-                                         world_size=world_size,
-                                        )
+    torch.distributed.init_process_group(
+        backend="nccl",
+        rank=rank,
+        world_size=world_size,
+    )
+
 
 def cleanup():
     """
@@ -25,23 +28,23 @@ def cleanup():
 
 def spawn_train(train_fxn, flags, world_size, device):
     """Spawns distributed training.
-    
+
     Args:
         train_fxn (function): Function to train model.
         flags (dict): Dictionary of flags.
         world_size (int): Number of processes.
         device (torch.device): torch device type
     """
-    torch.multiprocessing.spawn(train_fxn,
-                                args=(flags, world_size, device),
-                                nprocs=world_size,
-                                join=True
-                                )
+    torch.multiprocessing.spawn(
+        train_fxn, args=(flags, world_size, device), nprocs=world_size, join=True
+    )
 
 
-def get_data_distributed_dataloader_by_samples(path, input_length_sequence, batch_size, shuffle=True):
+def get_data_distributed_dataloader_by_samples(
+    path, input_length_sequence, batch_size, shuffle=True
+):
     """Returns a distributed dataloader.
-    
+
     Args:
         path (str): Path to dataset.
         input_length_sequence (int): Length of input sequence.
@@ -50,5 +53,10 @@ def get_data_distributed_dataloader_by_samples(path, input_length_sequence, batc
     """
     dataset = data_loader.SamplesDataset(path, input_length_sequence)
     sampler = DistributedSampler(dataset, shuffle=shuffle)
-    return torch.utils.data.DataLoader(dataset=dataset, sampler=sampler, batch_size=batch_size,
-                                       pin_memory=True, collate_fn=data_loader.collate_fn)
+    return torch.utils.data.DataLoader(
+        dataset=dataset,
+        sampler=sampler,
+        batch_size=batch_size,
+        pin_memory=True,
+        collate_fn=data_loader.collate_fn,
+    )

--- a/gns/graph_network.py
+++ b/gns/graph_network.py
@@ -5,405 +5,420 @@ from torch_geometric.nn import MessagePassing
 
 
 def build_mlp(
-        input_size: int,
-        hidden_layer_sizes: List[int],
-        output_size: int = None,
-        output_activation: nn.Module = nn.Identity,
-        activation: nn.Module = nn.ReLU) -> nn.Module:
-  """Build a MultiLayer Perceptron.
+    input_size: int,
+    hidden_layer_sizes: List[int],
+    output_size: int = None,
+    output_activation: nn.Module = nn.Identity,
+    activation: nn.Module = nn.ReLU,
+) -> nn.Module:
+    """Build a MultiLayer Perceptron.
 
-  Args:
-    input_size: Size of input layer.
-    layer_sizes: An array of input size for each hidden layer.
-    output_size: Size of the output layer.
-    output_activation: Activation function for the output layer.
-    activation: Activation function for the hidden layers.
+    Args:
+      input_size: Size of input layer.
+      layer_sizes: An array of input size for each hidden layer.
+      output_size: Size of the output layer.
+      output_activation: Activation function for the output layer.
+      activation: Activation function for the hidden layers.
 
-  Returns:
-    mlp: An MLP sequential container.
-  """
-  # Size of each layer
-  layer_sizes = [input_size] + hidden_layer_sizes
-  if output_size:
-    layer_sizes.append(output_size)
+    Returns:
+      mlp: An MLP sequential container.
+    """
+    # Size of each layer
+    layer_sizes = [input_size] + hidden_layer_sizes
+    if output_size:
+        layer_sizes.append(output_size)
 
-  # Number of layers
-  nlayers = len(layer_sizes) - 1
+    # Number of layers
+    nlayers = len(layer_sizes) - 1
 
-  # Create a list of activation functions and
-  # set the last element to output activation function
-  act = [activation for i in range(nlayers)]
-  act[-1] = output_activation
+    # Create a list of activation functions and
+    # set the last element to output activation function
+    act = [activation for i in range(nlayers)]
+    act[-1] = output_activation
 
-  # Create a torch sequential container
-  mlp = nn.Sequential()
-  for i in range(nlayers):
-    mlp.add_module("NN-" + str(i), nn.Linear(layer_sizes[i],
-                                             layer_sizes[i + 1]))
-    mlp.add_module("Act-" + str(i), act[i]())
+    # Create a torch sequential container
+    mlp = nn.Sequential()
+    for i in range(nlayers):
+        mlp.add_module("NN-" + str(i), nn.Linear(layer_sizes[i], layer_sizes[i + 1]))
+        mlp.add_module("Act-" + str(i), act[i]())
 
-  return mlp
+    return mlp
 
 
 class Encoder(nn.Module):
-  """Graph network encoder. Encode nodes and edges states to an MLP. The Encode:
-  :math: `\mathcal{X} \rightarrow \mathcal{G}` embeds the particle-based state
-  representation, :math: `\mathcal{X}`, as a latent graph, :math:
-  `G^0 = encoder(\mathcal{X})`, where :math: `G = (V, E, u), v_i \in V`, and
-  :math: `e_{i,j} in E`
-  """
-
-  def __init__(
-          self,
-          nnode_in_features: int,
-          nnode_out_features: int,
-          nedge_in_features: int,
-          nedge_out_features: int,
-          nmlp_layers: int,
-          mlp_hidden_dim: int):
-    """The Encoder implements nodes features :math: `\varepsilon_v` and edge
-    features :math: `\varepsilon_e` as multilayer perceptrons (MLP) into the
-    latent vectors, :math: `v_i` and :math: `e_{i,j}`, of size 128.
-
-    Args:
-      nnode_in_features: Number of node input features (for 2D = 30, calculated
-        as [10 = 5 times steps * 2 positions (x, y) +
-        4 distances to boundaries (top/bottom/left/right) +
-        16 particle type embeddings]).
-      nnode_out_features: Number of node output features (latent dimension of
-        size 128).
-      nedge_in_features: Number of edge input features (for 2D = 3, calculated
-        as [2 (x, y) relative displacements between 2 particles + distance
-        between 2 particles]).
-      nedge_out_features: Number of edge output features (latent dimension of
-        size 128).
-      nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
-      mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
-
+    """Graph network encoder. Encode nodes and edges states to an MLP. The Encode:
+    :math: `\mathcal{X} \rightarrow \mathcal{G}` embeds the particle-based state
+    representation, :math: `\mathcal{X}`, as a latent graph, :math:
+    `G^0 = encoder(\mathcal{X})`, where :math: `G = (V, E, u), v_i \in V`, and
+    :math: `e_{i,j} in E`
     """
-    super(Encoder, self).__init__()
-    # Encode node features as an MLP
-    self.node_fn = nn.Sequential(*[build_mlp(nnode_in_features,
-                                             [mlp_hidden_dim
-                                              for _ in range(nmlp_layers)],
-                                             nnode_out_features),
-                                   nn.LayerNorm(nnode_out_features)])
-    # Encode edge features as an MLP
-    self.edge_fn = nn.Sequential(*[build_mlp(nedge_in_features,
-                                             [mlp_hidden_dim
-                                              for _ in range(nmlp_layers)],
-                                             nedge_out_features),
-                                   nn.LayerNorm(nedge_out_features)])
 
-  def forward(
-          self,
-          x: torch.tensor,
-          edge_features: torch.tensor):
-    """The forward hook runs when the Encoder class is instantiated
+    def __init__(
+        self,
+        nnode_in_features: int,
+        nnode_out_features: int,
+        nedge_in_features: int,
+        nedge_out_features: int,
+        nmlp_layers: int,
+        mlp_hidden_dim: int,
+    ):
+        """The Encoder implements nodes features :math: `\varepsilon_v` and edge
+        features :math: `\varepsilon_e` as multilayer perceptrons (MLP) into the
+        latent vectors, :math: `v_i` and :math: `e_{i,j}`, of size 128.
 
-    Args:
-      x: Particle state representation as a torch tensor with shape
-        (nparticles, nnode_input_features)
-      edge_features: Edge features as a torch tensor with shape
-        (nparticles, nedge_input_features)
+        Args:
+          nnode_in_features: Number of node input features (for 2D = 30, calculated
+            as [10 = 5 times steps * 2 positions (x, y) +
+            4 distances to boundaries (top/bottom/left/right) +
+            16 particle type embeddings]).
+          nnode_out_features: Number of node output features (latent dimension of
+            size 128).
+          nedge_in_features: Number of edge input features (for 2D = 3, calculated
+            as [2 (x, y) relative displacements between 2 particles + distance
+            between 2 particles]).
+          nedge_out_features: Number of edge output features (latent dimension of
+            size 128).
+          nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
+          mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
 
-    """
-    return self.node_fn(x), self.edge_fn(edge_features)
+        """
+        super(Encoder, self).__init__()
+        # Encode node features as an MLP
+        self.node_fn = nn.Sequential(
+            *[
+                build_mlp(
+                    nnode_in_features,
+                    [mlp_hidden_dim for _ in range(nmlp_layers)],
+                    nnode_out_features,
+                ),
+                nn.LayerNorm(nnode_out_features),
+            ]
+        )
+        # Encode edge features as an MLP
+        self.edge_fn = nn.Sequential(
+            *[
+                build_mlp(
+                    nedge_in_features,
+                    [mlp_hidden_dim for _ in range(nmlp_layers)],
+                    nedge_out_features,
+                ),
+                nn.LayerNorm(nedge_out_features),
+            ]
+        )
+
+    def forward(self, x: torch.tensor, edge_features: torch.tensor):
+        """The forward hook runs when the Encoder class is instantiated
+
+        Args:
+          x: Particle state representation as a torch tensor with shape
+            (nparticles, nnode_input_features)
+          edge_features: Edge features as a torch tensor with shape
+            (nparticles, nedge_input_features)
+
+        """
+        return self.node_fn(x), self.edge_fn(edge_features)
 
 
 class InteractionNetwork(MessagePassing):
-  def __init__(
-      self,
-      nnode_in: int,
-      nnode_out: int,
-      nedge_in: int,
-      nedge_out: int,
-      nmlp_layers: int,
-      mlp_hidden_dim: int,
-  ):
-    """InteractionNetwork derived from torch_geometric MessagePassing class
+    def __init__(
+        self,
+        nnode_in: int,
+        nnode_out: int,
+        nedge_in: int,
+        nedge_out: int,
+        nmlp_layers: int,
+        mlp_hidden_dim: int,
+    ):
+        """InteractionNetwork derived from torch_geometric MessagePassing class
 
-    Args:
-      nnode_in: Number of node inputs (latent dimension of size 128).
-      nnode_out: Number of node outputs (latent dimension of size 128).
-      nedge_in: Number of edge inputs (latent dimension of size 128).
-      nedge_out: Number of edge output features (latent dimension of size 128).
-      nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
-      mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
+        Args:
+          nnode_in: Number of node inputs (latent dimension of size 128).
+          nnode_out: Number of node outputs (latent dimension of size 128).
+          nedge_in: Number of edge inputs (latent dimension of size 128).
+          nedge_out: Number of edge output features (latent dimension of size 128).
+          nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
+          mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
 
-    """
-    # Aggregate features from neighbors
-    super(InteractionNetwork, self).__init__(aggr='add')
-    # Node MLP
-    self.node_fn = nn.Sequential(*[build_mlp(nnode_in + nedge_out,
-                                             [mlp_hidden_dim
-                                              for _ in range(nmlp_layers)],
-                                             nnode_out),
-                                   nn.LayerNorm(nnode_out)])
-    # Edge MLP
-    self.edge_fn = nn.Sequential(*[build_mlp(nnode_in + nnode_in + nedge_in,
-                                             [mlp_hidden_dim
-                                              for _ in range(nmlp_layers)],
-                                             nedge_out),
-                                   nn.LayerNorm(nedge_out)])
+        """
+        # Aggregate features from neighbors
+        super(InteractionNetwork, self).__init__(aggr="add")
+        # Node MLP
+        self.node_fn = nn.Sequential(
+            *[
+                build_mlp(
+                    nnode_in + nedge_out,
+                    [mlp_hidden_dim for _ in range(nmlp_layers)],
+                    nnode_out,
+                ),
+                nn.LayerNorm(nnode_out),
+            ]
+        )
+        # Edge MLP
+        self.edge_fn = nn.Sequential(
+            *[
+                build_mlp(
+                    nnode_in + nnode_in + nedge_in,
+                    [mlp_hidden_dim for _ in range(nmlp_layers)],
+                    nedge_out,
+                ),
+                nn.LayerNorm(nedge_out),
+            ]
+        )
 
-  def forward(self,
-              x: torch.tensor,
-              edge_index: torch.tensor,
-              edge_features: torch.tensor):
-    """The forward hook runs when the InteractionNetwork class is instantiated
+    def forward(
+        self, x: torch.tensor, edge_index: torch.tensor, edge_features: torch.tensor
+    ):
+        """The forward hook runs when the InteractionNetwork class is instantiated
 
-    Args:
-      x: Particle state representation as a torch tensor with shape
-        (nparticles, nnode_input_features)
-      edge_index: A torch tensor list of source and target nodes with shape
-        (2, nedges)
-      edge_features: Edge features as a torch tensor with shape
-        (nedges, nedge_in=latent_dim of 128)
+        Args:
+          x: Particle state representation as a torch tensor with shape
+            (nparticles, nnode_input_features)
+          edge_index: A torch tensor list of source and target nodes with shape
+            (2, nedges)
+          edge_features: Edge features as a torch tensor with shape
+            (nedges, nedge_in=latent_dim of 128)
 
-    Returns:
-      tuple: Updated node and edge features
-    """
-    # Save particle state and edge features
-    x_residual = x
-    edge_features_residual = edge_features
-    # Start propagating messages.
-    # Takes in the edge indices and all additional data which is needed to
-    # construct messages and to update node embeddings.
-    x, edge_features = self.propagate(
-        edge_index=edge_index, x=x, edge_features=edge_features)
+        Returns:
+          tuple: Updated node and edge features
+        """
+        # Save particle state and edge features
+        x_residual = x
+        edge_features_residual = edge_features
+        # Start propagating messages.
+        # Takes in the edge indices and all additional data which is needed to
+        # construct messages and to update node embeddings.
+        x, edge_features = self.propagate(
+            edge_index=edge_index, x=x, edge_features=edge_features
+        )
 
-    return x + x_residual, edge_features + edge_features_residual
+        return x + x_residual, edge_features + edge_features_residual
 
-  def message(self,
-              x_i: torch.tensor,
-              x_j: torch.tensor,
-              edge_features: torch.tensor) -> torch.tensor:
-    """Constructs message from j to i of edge :math:`e_{i, j}`. Tensors :obj:`x`
-    passed to :meth:`propagate` can be mapped to the respective nodes :math:`i`
-    and :math:`j` by appending :obj:`_i` or :obj:`_j` to the variable name,
-    i.e., :obj:`x_i` and :obj:`x_j`.
+    def message(
+        self, x_i: torch.tensor, x_j: torch.tensor, edge_features: torch.tensor
+    ) -> torch.tensor:
+        """Constructs message from j to i of edge :math:`e_{i, j}`. Tensors :obj:`x`
+        passed to :meth:`propagate` can be mapped to the respective nodes :math:`i`
+        and :math:`j` by appending :obj:`_i` or :obj:`_j` to the variable name,
+        i.e., :obj:`x_i` and :obj:`x_j`.
 
-    Args:
-      x_i: Particle state representation as a torch tensor with shape
-        (nparticles, nnode_in=latent_dim of 128) at node i
-      x_j: Particle state representation as a torch tensor with shape
-        (nparticles, nnode_in=latent_dim of 128) at node j
-      edge_features: Edge features as a torch tensor with shape
-        (nedges, nedge_in=latent_dim of 128)
+        Args:
+          x_i: Particle state representation as a torch tensor with shape
+            (nparticles, nnode_in=latent_dim of 128) at node i
+          x_j: Particle state representation as a torch tensor with shape
+            (nparticles, nnode_in=latent_dim of 128) at node j
+          edge_features: Edge features as a torch tensor with shape
+            (nedges, nedge_in=latent_dim of 128)
 
-    """
-    # Concat edge features with a final shape of [nedges, latent_dim*3]
-    edge_features = torch.cat([x_i, x_j, edge_features], dim=-1)
-    edge_features = self.edge_fn(edge_features)
-    return edge_features
+        """
+        # Concat edge features with a final shape of [nedges, latent_dim*3]
+        edge_features = torch.cat([x_i, x_j, edge_features], dim=-1)
+        edge_features = self.edge_fn(edge_features)
+        return edge_features
 
-  def update(self,
-             x_updated: torch.tensor,
-             x: torch.tensor,
-             edge_features: torch.tensor):
-    """Update the particle state representation
+    def update(
+        self, x_updated: torch.tensor, x: torch.tensor, edge_features: torch.tensor
+    ):
+        """Update the particle state representation
 
-    Args:
-      x: Particle state representation as a torch tensor with shape 
-        (nparticles, nnode_in=latent_dim of 128)
-      x_updated: Updated particle state representation as a torch tensor with 
-        shape (nparticles, nnode_in=latent_dim of 128)
-      edge_features: Edge features as a torch tensor with shape 
-        (nedges, nedge_out=latent_dim of 128)
+        Args:
+          x: Particle state representation as a torch tensor with shape
+            (nparticles, nnode_in=latent_dim of 128)
+          x_updated: Updated particle state representation as a torch tensor with
+            shape (nparticles, nnode_in=latent_dim of 128)
+          edge_features: Edge features as a torch tensor with shape
+            (nedges, nedge_out=latent_dim of 128)
 
-    Returns:
-      tuple: Updated node and edge features
-    """
-    # Concat node features with a final shape of
-    # [nparticles, latent_dim (or nnode_in) *2]
-    x_updated = torch.cat([x_updated, x], dim=-1)
-    x_updated = self.node_fn(x_updated)
-    return x_updated, edge_features
+        Returns:
+          tuple: Updated node and edge features
+        """
+        # Concat node features with a final shape of
+        # [nparticles, latent_dim (or nnode_in) *2]
+        x_updated = torch.cat([x_updated, x], dim=-1)
+        x_updated = self.node_fn(x_updated)
+        return x_updated, edge_features
 
 
 class Processor(MessagePassing):
-  """The Processor: :math: `\mathcal{G} \rightarrow \mathcal{G}` computes 
-  interactions among nodes via :math: `M` steps of learned message-passing, to 
-  generate a sequence of updated latent graphs, :math: `G = (G_1 , ..., G_M )`, 
-  where :math: `G^{m+1| = GN^{m+1} (G^m )`. It returns the final graph, 
-  :math: `G^M = PROCESSOR(G^0)`. Message-passing allows information to 
-  propagate and constraints to be respected: the number of message-passing 
-  steps required will likely scale with the complexity of the interactions.
-
-  """
-
-  def __init__(
-      self,
-      nnode_in: int,
-      nnode_out: int,
-      nedge_in: int,
-      nedge_out: int,
-      nmessage_passing_steps: int,
-      nmlp_layers: int,
-      mlp_hidden_dim: int,
-  ):
-    """Processor derived from torch_geometric MessagePassing class. The 
-    processor uses a stack of :math: `M GNs` (where :math: `M` is a 
-    hyperparameter) with identical structure, MLPs as internal edge and node 
-    update functions, and either shared or unshared parameters. We use GNs 
-    without global features or global updates (i.e., an interaction network), 
-    and with a residual connections between the input and output latent node 
-    and edge attributes.
-
-    Args:
-      nnode_in: Number of node inputs (latent dimension of size 128).
-      nnode_out: Number of node outputs (latent dimension of size 128).
-      nedge_in: Number of edge inputs (latent dimension of size 128).
-      nedge_out: Number of edge output features (latent dimension of size 128).
-      nmessage_passing_steps: Number of message passing steps.
-      nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
-      mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
+    """The Processor: :math: `\mathcal{G} \rightarrow \mathcal{G}` computes
+    interactions among nodes via :math: `M` steps of learned message-passing, to
+    generate a sequence of updated latent graphs, :math: `G = (G_1 , ..., G_M )`,
+    where :math: `G^{m+1| = GN^{m+1} (G^m )`. It returns the final graph,
+    :math: `G^M = PROCESSOR(G^0)`. Message-passing allows information to
+    propagate and constraints to be respected: the number of message-passing
+    steps required will likely scale with the complexity of the interactions.
 
     """
-    super(Processor, self).__init__(aggr='max')
-    # Create a stack of M Graph Networks GNs.
-    self.gnn_stacks = nn.ModuleList([
-        InteractionNetwork(
-            nnode_in=nnode_in,
-            nnode_out=nnode_out,
-            nedge_in=nedge_in,
-            nedge_out=nedge_out,
-            nmlp_layers=nmlp_layers,
-            mlp_hidden_dim=mlp_hidden_dim,
-        ) for _ in range(nmessage_passing_steps)])
 
-  def forward(self,
-              x: torch.tensor,
-              edge_index: torch.tensor,
-              edge_features: torch.tensor):
-    """The forward hook runs through GNN stacks when class is instantiated. 
+    def __init__(
+        self,
+        nnode_in: int,
+        nnode_out: int,
+        nedge_in: int,
+        nedge_out: int,
+        nmessage_passing_steps: int,
+        nmlp_layers: int,
+        mlp_hidden_dim: int,
+    ):
+        """Processor derived from torch_geometric MessagePassing class. The
+        processor uses a stack of :math: `M GNs` (where :math: `M` is a
+        hyperparameter) with identical structure, MLPs as internal edge and node
+        update functions, and either shared or unshared parameters. We use GNs
+        without global features or global updates (i.e., an interaction network),
+        and with a residual connections between the input and output latent node
+        and edge attributes.
 
-    Args:
-      x: Particle state representation as a torch tensor with shape 
-        (nparticles, latent_dim)
-      edge_index: A torch tensor list of source and target nodes with shape 
-        (2, nedges)
-      edge_features: Edge features as a torch tensor with shape 
-        (nparticles, latent_dim)
+        Args:
+          nnode_in: Number of node inputs (latent dimension of size 128).
+          nnode_out: Number of node outputs (latent dimension of size 128).
+          nedge_in: Number of edge inputs (latent dimension of size 128).
+          nedge_out: Number of edge output features (latent dimension of size 128).
+          nmessage_passing_steps: Number of message passing steps.
+          nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
+          mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
 
-    """
-    for gnn in self.gnn_stacks:
-      x, edge_features = gnn(x, edge_index, edge_features)
-    return x, edge_features
+        """
+        super(Processor, self).__init__(aggr="max")
+        # Create a stack of M Graph Networks GNs.
+        self.gnn_stacks = nn.ModuleList(
+            [
+                InteractionNetwork(
+                    nnode_in=nnode_in,
+                    nnode_out=nnode_out,
+                    nedge_in=nedge_in,
+                    nedge_out=nedge_out,
+                    nmlp_layers=nmlp_layers,
+                    mlp_hidden_dim=mlp_hidden_dim,
+                )
+                for _ in range(nmessage_passing_steps)
+            ]
+        )
+
+    def forward(
+        self, x: torch.tensor, edge_index: torch.tensor, edge_features: torch.tensor
+    ):
+        """The forward hook runs through GNN stacks when class is instantiated.
+
+        Args:
+          x: Particle state representation as a torch tensor with shape
+            (nparticles, latent_dim)
+          edge_index: A torch tensor list of source and target nodes with shape
+            (2, nedges)
+          edge_features: Edge features as a torch tensor with shape
+            (nparticles, latent_dim)
+
+        """
+        for gnn in self.gnn_stacks:
+            x, edge_features = gnn(x, edge_index, edge_features)
+        return x, edge_features
 
 
 class Decoder(nn.Module):
-  """The Decoder: :math: `\mathcal{G} \rightarrow \mathcal{Y}` extracts the 
-  dynamics information from the nodes of the final latent graph, 
-  :math: `y_i = \delta v (v_i^M)`
-
-  """
-
-  def __init__(
-          self,
-          nnode_in: int,
-          nnode_out: int,
-          nmlp_layers: int,
-          mlp_hidden_dim: int):
-    """The Decoder coder's learned function, :math: `\detla v`, is an MLP. 
-    After the Decoder, the future position and velocity are updated using an 
-    Euler integrator, so the :math: `yi` corresponds to accelerations, 
-    :math: `\"{p}_i`, with 2D or 3D dimension, depending on the physical domain.
-
-    Args:
-      nnode_in: Number of node inputs (latent dimension of size 128).
-      nnode_out: Number of node outputs (particle dimension).
-      nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
-      mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
-    """
-    super(Decoder, self).__init__()
-    self.node_fn = build_mlp(
-        nnode_in, [mlp_hidden_dim for _ in range(nmlp_layers)], nnode_out)
-
-  def forward(self,
-              x: torch.tensor):
-    """The forward hook runs when the Decoder class is instantiated
-
-    Args:
-      x: Particle state representation as a torch tensor with shape 
-        (nparticles, nnode_in)
+    """The Decoder: :math: `\mathcal{G} \rightarrow \mathcal{Y}` extracts the
+    dynamics information from the nodes of the final latent graph,
+    :math: `y_i = \delta v (v_i^M)`
 
     """
-    return self.node_fn(x)
+
+    def __init__(
+        self, nnode_in: int, nnode_out: int, nmlp_layers: int, mlp_hidden_dim: int
+    ):
+        """The Decoder coder's learned function, :math: `\detla v`, is an MLP.
+        After the Decoder, the future position and velocity are updated using an
+        Euler integrator, so the :math: `yi` corresponds to accelerations,
+        :math: `\"{p}_i`, with 2D or 3D dimension, depending on the physical domain.
+
+        Args:
+          nnode_in: Number of node inputs (latent dimension of size 128).
+          nnode_out: Number of node outputs (particle dimension).
+          nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
+          mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
+        """
+        super(Decoder, self).__init__()
+        self.node_fn = build_mlp(
+            nnode_in, [mlp_hidden_dim for _ in range(nmlp_layers)], nnode_out
+        )
+
+    def forward(self, x: torch.tensor):
+        """The forward hook runs when the Decoder class is instantiated
+
+        Args:
+          x: Particle state representation as a torch tensor with shape
+            (nparticles, nnode_in)
+
+        """
+        return self.node_fn(x)
 
 
 class EncodeProcessDecode(nn.Module):
-  def __init__(
-      self,
-      nnode_in_features: int,
-      nnode_out_features: int,
-      nedge_in_features: int,
-      latent_dim: int,
-      nmessage_passing_steps: int,
-      nmlp_layers: int,
-      mlp_hidden_dim: int,
-  ):
-    """Encode-Process-Decode function approximator for learnable simulator.
+    def __init__(
+        self,
+        nnode_in_features: int,
+        nnode_out_features: int,
+        nedge_in_features: int,
+        latent_dim: int,
+        nmessage_passing_steps: int,
+        nmlp_layers: int,
+        mlp_hidden_dim: int,
+    ):
+        """Encode-Process-Decode function approximator for learnable simulator.
 
-    Args:
-      nnode_in_features: Number of node input features (for 2D = 30, 
-        calculated as [10 = 5 times steps * 2 positions (x, y) + 
-        4 distances to boundaries (top/bottom/left/right) + 
-        16 particle type embeddings]).
-      nnode_out_features:  Number of node outputs (particle dimension).
-      nedge_in_features: Number of edge input features (for 2D = 3, 
-        calculated as [2 (x, y) relative displacements between 2 particles + 
-        distance between 2 particles]).
-      latent_dim: Size of latent dimension (128)
-      nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
-      mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
+        Args:
+          nnode_in_features: Number of node input features (for 2D = 30,
+            calculated as [10 = 5 times steps * 2 positions (x, y) +
+            4 distances to boundaries (top/bottom/left/right) +
+            16 particle type embeddings]).
+          nnode_out_features:  Number of node outputs (particle dimension).
+          nedge_in_features: Number of edge input features (for 2D = 3,
+            calculated as [2 (x, y) relative displacements between 2 particles +
+            distance between 2 particles]).
+          latent_dim: Size of latent dimension (128)
+          nmlp_layer: Number of hidden layers in the MLP (typically of size 2).
+          mlp_hidden_dim: Size of the hidden layer (latent dimension of size 128).
 
-    """
-    super(EncodeProcessDecode, self).__init__()
-    self._encoder = Encoder(
-        nnode_in_features=nnode_in_features,
-        nnode_out_features=latent_dim,
-        nedge_in_features=nedge_in_features,
-        nedge_out_features=latent_dim,
-        nmlp_layers=nmlp_layers,
-        mlp_hidden_dim=mlp_hidden_dim,
-    )
-    self._processor = Processor(
-        nnode_in=latent_dim,
-        nnode_out=latent_dim,
-        nedge_in=latent_dim,
-        nedge_out=latent_dim,
-        nmessage_passing_steps=nmessage_passing_steps,
-        nmlp_layers=nmlp_layers,
-        mlp_hidden_dim=mlp_hidden_dim,
-    )
-    self._decoder = Decoder(
-        nnode_in=latent_dim,
-        nnode_out=nnode_out_features,
-        nmlp_layers=nmlp_layers,
-        mlp_hidden_dim=mlp_hidden_dim,
-    )
+        """
+        super(EncodeProcessDecode, self).__init__()
+        self._encoder = Encoder(
+            nnode_in_features=nnode_in_features,
+            nnode_out_features=latent_dim,
+            nedge_in_features=nedge_in_features,
+            nedge_out_features=latent_dim,
+            nmlp_layers=nmlp_layers,
+            mlp_hidden_dim=mlp_hidden_dim,
+        )
+        self._processor = Processor(
+            nnode_in=latent_dim,
+            nnode_out=latent_dim,
+            nedge_in=latent_dim,
+            nedge_out=latent_dim,
+            nmessage_passing_steps=nmessage_passing_steps,
+            nmlp_layers=nmlp_layers,
+            mlp_hidden_dim=mlp_hidden_dim,
+        )
+        self._decoder = Decoder(
+            nnode_in=latent_dim,
+            nnode_out=nnode_out_features,
+            nmlp_layers=nmlp_layers,
+            mlp_hidden_dim=mlp_hidden_dim,
+        )
 
-  def forward(self,
-              x: torch.tensor,
-              edge_index: torch.tensor,
-              edge_features: torch.tensor):
-    """The forward hook runs at instatiation of EncodeProcessorDecode class.
+    def forward(
+        self, x: torch.tensor, edge_index: torch.tensor, edge_features: torch.tensor
+    ):
+        """The forward hook runs at instatiation of EncodeProcessorDecode class.
 
-      Args:
-        x: Particle state representation as a torch tensor with shape 
-          (nparticles, nnode_in_features)
-        edge_index: A torch tensor list of source and target nodes with shape 
-          (2, nedges)
-        edge_features: Edge features as a torch tensor with shape 
-          (nedges, nedge_in_features)
-          
-      Returns:
-        x: Particle state representation as a torch tensor with shape
-          (nparticles, nnode_out_features)
-    """
-    x, edge_features = self._encoder(x, edge_features)
-    x, edge_features = self._processor(x, edge_index, edge_features)
-    x = self._decoder(x)
-    return x
+        Args:
+          x: Particle state representation as a torch tensor with shape
+            (nparticles, nnode_in_features)
+          edge_index: A torch tensor list of source and target nodes with shape
+            (2, nedges)
+          edge_features: Edge features as a torch tensor with shape
+            (nedges, nedge_in_features)
+
+        Returns:
+          x: Particle state representation as a torch tensor with shape
+            (nparticles, nnode_out_features)
+        """
+        x, edge_features = self._encoder(x, edge_features)
+        x, edge_features = self._processor(x, edge_index, edge_features)
+        x = self._decoder(x)
+        return x

--- a/gns/learned_simulator.py
+++ b/gns/learned_simulator.py
@@ -7,379 +7,405 @@ from typing import Dict
 
 
 class LearnedSimulator(nn.Module):
-  """Learned simulator from https://arxiv.org/pdf/2002.09405.pdf."""
+    """Learned simulator from https://arxiv.org/pdf/2002.09405.pdf."""
 
-  def __init__(
-          self,
-          particle_dimensions: int,
-          nnode_in: int,
-          nedge_in: int,
-          latent_dim: int,
-          nmessage_passing_steps: int,
-          nmlp_layers: int,
-          mlp_hidden_dim: int,
-          connectivity_radius: float,
-          boundaries: np.ndarray,
-          normalization_stats: dict,
-          nparticle_types: int,
-          particle_type_embedding_size: int,
-          boundary_clamp_limit: float = 1.0,
-          device="cpu"
-  ):
-    """Initializes the model.
+    def __init__(
+        self,
+        particle_dimensions: int,
+        nnode_in: int,
+        nedge_in: int,
+        latent_dim: int,
+        nmessage_passing_steps: int,
+        nmlp_layers: int,
+        mlp_hidden_dim: int,
+        connectivity_radius: float,
+        boundaries: np.ndarray,
+        normalization_stats: dict,
+        nparticle_types: int,
+        particle_type_embedding_size: int,
+        boundary_clamp_limit: float = 1.0,
+        device="cpu",
+    ):
+        """Initializes the model.
 
-    Args:
-      particle_dimensions: Dimensionality of the problem.
-      nnode_in: Number of node inputs.
-      nedge_in: Number of edge inputs.
-      latent_dim: Size of latent dimension (128)
-      nmessage_passing_steps: Number of message passing steps.
-      nmlp_layers: Number of hidden layers in the MLP (typically of size 2).
-      connectivity_radius: Scalar with the radius of connectivity.
-      boundaries: Array of 2-tuples, containing the lower and upper boundaries
-        of the cuboid containing the particles along each dimensions, matching
-        the dimensionality of the problem.
-      normalization_stats: Dictionary with statistics with keys "acceleration"
-        and "velocity", containing a named tuple for each with mean and std
-        fields, matching the dimensionality of the problem.
-      nparticle_types: Number of different particle types.
-      particle_type_embedding_size: Embedding size for the particle type.
-      boundary_clamp_limit: a factor to enlarge connectivity radius used for computing
-        normalized clipped distance in edge feature.
-      device: Runtime device (cuda or cpu).
+        Args:
+          particle_dimensions: Dimensionality of the problem.
+          nnode_in: Number of node inputs.
+          nedge_in: Number of edge inputs.
+          latent_dim: Size of latent dimension (128)
+          nmessage_passing_steps: Number of message passing steps.
+          nmlp_layers: Number of hidden layers in the MLP (typically of size 2).
+          connectivity_radius: Scalar with the radius of connectivity.
+          boundaries: Array of 2-tuples, containing the lower and upper boundaries
+            of the cuboid containing the particles along each dimensions, matching
+            the dimensionality of the problem.
+          normalization_stats: Dictionary with statistics with keys "acceleration"
+            and "velocity", containing a named tuple for each with mean and std
+            fields, matching the dimensionality of the problem.
+          nparticle_types: Number of different particle types.
+          particle_type_embedding_size: Embedding size for the particle type.
+          boundary_clamp_limit: a factor to enlarge connectivity radius used for computing
+            normalized clipped distance in edge feature.
+          device: Runtime device (cuda or cpu).
 
-    """
-    super(LearnedSimulator, self).__init__()
-    self._boundaries = boundaries
-    self._connectivity_radius = connectivity_radius
-    self._normalization_stats = normalization_stats
-    self._nparticle_types = nparticle_types
-    self._boundary_clamp_limit = boundary_clamp_limit
+        """
+        super(LearnedSimulator, self).__init__()
+        self._boundaries = boundaries
+        self._connectivity_radius = connectivity_radius
+        self._normalization_stats = normalization_stats
+        self._nparticle_types = nparticle_types
+        self._boundary_clamp_limit = boundary_clamp_limit
 
-    # Particle type embedding has shape (9, 16)
-    self._particle_type_embedding = nn.Embedding(
-        nparticle_types, particle_type_embedding_size)
+        # Particle type embedding has shape (9, 16)
+        self._particle_type_embedding = nn.Embedding(
+            nparticle_types, particle_type_embedding_size
+        )
 
-    # Initialize the EncodeProcessDecode
-    self._encode_process_decode = graph_network.EncodeProcessDecode(
-        nnode_in_features=nnode_in,
-        nnode_out_features=particle_dimensions,
-        nedge_in_features=nedge_in,
-        latent_dim=latent_dim,
-        nmessage_passing_steps=nmessage_passing_steps,
-        nmlp_layers=nmlp_layers,
-        mlp_hidden_dim=mlp_hidden_dim)
+        # Initialize the EncodeProcessDecode
+        self._encode_process_decode = graph_network.EncodeProcessDecode(
+            nnode_in_features=nnode_in,
+            nnode_out_features=particle_dimensions,
+            nedge_in_features=nedge_in,
+            latent_dim=latent_dim,
+            nmessage_passing_steps=nmessage_passing_steps,
+            nmlp_layers=nmlp_layers,
+            mlp_hidden_dim=mlp_hidden_dim,
+        )
 
-    self._device = device
+        self._device = device
 
-  def forward(self):
-    """Forward hook runs on class instantiation"""
-    pass
+    def forward(self):
+        """Forward hook runs on class instantiation"""
+        pass
 
-  def _compute_graph_connectivity(
-          self,
-          node_features: torch.tensor,
-          nparticles_per_example: torch.tensor,
-          radius: float,
-          add_self_edges: bool = True):
-    """Generate graph edges to all particles within a threshold radius
+    def _compute_graph_connectivity(
+        self,
+        node_features: torch.tensor,
+        nparticles_per_example: torch.tensor,
+        radius: float,
+        add_self_edges: bool = True,
+    ):
+        """Generate graph edges to all particles within a threshold radius
 
-    Args:
-      node_features: Node features with shape (nparticles, dim).
-      nparticles_per_example: Number of particles per example. Default is 2
-        examples per batch.
-      radius: Threshold to construct edges to all particles within the radius.
-      add_self_edges: Boolean flag to include self edge (default: True)
-    """
-    # Specify examples id for particles
-    batch_ids = torch.cat(
-        [torch.LongTensor([i for _ in range(n)])
-         for i, n in enumerate(nparticles_per_example)]).to(self._device)
+        Args:
+          node_features: Node features with shape (nparticles, dim).
+          nparticles_per_example: Number of particles per example. Default is 2
+            examples per batch.
+          radius: Threshold to construct edges to all particles within the radius.
+          add_self_edges: Boolean flag to include self edge (default: True)
+        """
+        # Specify examples id for particles
+        batch_ids = torch.cat(
+            [
+                torch.LongTensor([i for _ in range(n)])
+                for i, n in enumerate(nparticles_per_example)
+            ]
+        ).to(self._device)
 
-    # radius_graph accepts r < radius not r <= radius
-    # A torch tensor list of source and target nodes with shape (2, nedges)
-    edge_index = radius_graph(
-        node_features, r=radius, batch=batch_ids, loop=add_self_edges, max_num_neighbors=128)
+        # radius_graph accepts r < radius not r <= radius
+        # A torch tensor list of source and target nodes with shape (2, nedges)
+        edge_index = radius_graph(
+            node_features,
+            r=radius,
+            batch=batch_ids,
+            loop=add_self_edges,
+            max_num_neighbors=128,
+        )
 
-    # The flow direction when using in combination with message passing is
-    # "source_to_target"
-    receivers = edge_index[0, :]
-    senders = edge_index[1, :]
+        # The flow direction when using in combination with message passing is
+        # "source_to_target"
+        receivers = edge_index[0, :]
+        senders = edge_index[1, :]
 
-    return receivers, senders
+        return receivers, senders
 
-  def _encoder_preprocessor(
-          self,
-          position_sequence: torch.tensor,
-          nparticles_per_example: torch.tensor,
-          particle_types: torch.tensor,
-          material_property: torch.tensor = None):
-    """Extracts important features from the position sequence. Returns a tuple
-    of node_features (nparticles, 30), edge_index (nparticles, nparticles), and
-    edge_features (nparticles, 3).
+    def _encoder_preprocessor(
+        self,
+        position_sequence: torch.tensor,
+        nparticles_per_example: torch.tensor,
+        particle_types: torch.tensor,
+        material_property: torch.tensor = None,
+    ):
+        """Extracts important features from the position sequence. Returns a tuple
+        of node_features (nparticles, 30), edge_index (nparticles, nparticles), and
+        edge_features (nparticles, 3).
 
-    Args:
-      position_sequence: A sequence of particle positions. Shape is
-        (nparticles, 6, dim). Includes current + last 5 positions
-      nparticles_per_example: Number of particles per example. Default is 2
-        examples per batch.
-      particle_types: Particle types with shape (nparticles).
-      material_property: Friction angle normalized by tan() with shape (nparticles)
-    """
-    nparticles = position_sequence.shape[0]
-    most_recent_position = position_sequence[:, -1]  # (n_nodes, 2)
-    velocity_sequence = time_diff(position_sequence)
+        Args:
+          position_sequence: A sequence of particle positions. Shape is
+            (nparticles, 6, dim). Includes current + last 5 positions
+          nparticles_per_example: Number of particles per example. Default is 2
+            examples per batch.
+          particle_types: Particle types with shape (nparticles).
+          material_property: Friction angle normalized by tan() with shape (nparticles)
+        """
+        nparticles = position_sequence.shape[0]
+        most_recent_position = position_sequence[:, -1]  # (n_nodes, 2)
+        velocity_sequence = time_diff(position_sequence)
 
-    # Get connectivity of the graph with shape of (nparticles, 2)
-    senders, receivers = self._compute_graph_connectivity(
-        most_recent_position, nparticles_per_example, self._connectivity_radius)
-    node_features = []
+        # Get connectivity of the graph with shape of (nparticles, 2)
+        senders, receivers = self._compute_graph_connectivity(
+            most_recent_position, nparticles_per_example, self._connectivity_radius
+        )
+        node_features = []
 
-    # Normalized velocity sequence, merging spatial an time axis.
-    velocity_stats = self._normalization_stats["velocity"]
-    normalized_velocity_sequence = (
-        velocity_sequence - velocity_stats['mean']) / velocity_stats['std']
-    flat_velocity_sequence = normalized_velocity_sequence.view(
-        nparticles, -1)
-    # There are 5 previous steps, with dim 2
-    # node_features shape (nparticles, 5 * 2 = 10)
-    node_features.append(flat_velocity_sequence)
+        # Normalized velocity sequence, merging spatial an time axis.
+        velocity_stats = self._normalization_stats["velocity"]
+        normalized_velocity_sequence = (
+            velocity_sequence - velocity_stats["mean"]
+        ) / velocity_stats["std"]
+        flat_velocity_sequence = normalized_velocity_sequence.view(nparticles, -1)
+        # There are 5 previous steps, with dim 2
+        # node_features shape (nparticles, 5 * 2 = 10)
+        node_features.append(flat_velocity_sequence)
 
-    # Normalized clipped distances to lower and upper boundaries.
-    # boundaries are an array of shape [num_dimensions, 2], where the second
-    # axis, provides the lower/upper boundaries.
-    boundaries = torch.tensor(
-        self._boundaries, requires_grad=False).float().to(self._device)
-    distance_to_lower_boundary = (
-        most_recent_position - boundaries[:, 0][None])
-    distance_to_upper_boundary = (
-        boundaries[:, 1][None] - most_recent_position)
-    distance_to_boundaries = torch.cat(
-        [distance_to_lower_boundary, distance_to_upper_boundary], dim=1)
-    normalized_clipped_distance_to_boundaries = torch.clamp(
-        distance_to_boundaries / self._connectivity_radius,
-        -self._boundary_clamp_limit, self._boundary_clamp_limit)
-    # The distance to 4 boundaries (top/bottom/left/right)
-    # node_features shape (nparticles, 10+4)
-    node_features.append(normalized_clipped_distance_to_boundaries)
+        # Normalized clipped distances to lower and upper boundaries.
+        # boundaries are an array of shape [num_dimensions, 2], where the second
+        # axis, provides the lower/upper boundaries.
+        boundaries = (
+            torch.tensor(self._boundaries, requires_grad=False).float().to(self._device)
+        )
+        distance_to_lower_boundary = most_recent_position - boundaries[:, 0][None]
+        distance_to_upper_boundary = boundaries[:, 1][None] - most_recent_position
+        distance_to_boundaries = torch.cat(
+            [distance_to_lower_boundary, distance_to_upper_boundary], dim=1
+        )
+        normalized_clipped_distance_to_boundaries = torch.clamp(
+            distance_to_boundaries / self._connectivity_radius,
+            -self._boundary_clamp_limit,
+            self._boundary_clamp_limit,
+        )
+        # The distance to 4 boundaries (top/bottom/left/right)
+        # node_features shape (nparticles, 10+4)
+        node_features.append(normalized_clipped_distance_to_boundaries)
 
-    # Particle type
-    if self._nparticle_types > 1:
-      particle_type_embeddings = self._particle_type_embedding(
-          particle_types)
-      node_features.append(particle_type_embeddings)
-    # Final node_features shape (nparticles, 30) for 2D (if material_property is not valid in training example)
-    # 30 = 10 (5 velocity sequences*dim) + 4 boundaries + 16 particle embedding
+        # Particle type
+        if self._nparticle_types > 1:
+            particle_type_embeddings = self._particle_type_embedding(particle_types)
+            node_features.append(particle_type_embeddings)
+        # Final node_features shape (nparticles, 30) for 2D (if material_property is not valid in training example)
+        # 30 = 10 (5 velocity sequences*dim) + 4 boundaries + 16 particle embedding
 
-    # Material property
-    if material_property is not None:
-        material_property = material_property.view(nparticles, 1)
-        node_features.append(material_property)
-    # Final node_features shape (nparticles, 31) for 2D
-    # 31 = 10 (5 velocity sequences*dim) + 4 boundaries + 16 particle embedding + 1 material property
+        # Material property
+        if material_property is not None:
+            material_property = material_property.view(nparticles, 1)
+            node_features.append(material_property)
+        # Final node_features shape (nparticles, 31) for 2D
+        # 31 = 10 (5 velocity sequences*dim) + 4 boundaries + 16 particle embedding + 1 material property
 
-    # Collect edge features.
-    edge_features = []
+        # Collect edge features.
+        edge_features = []
 
-    # Relative displacement and distances normalized to radius
-    # with shape (nedges, 2)
-    # normalized_relative_displacements = (
-    #     torch.gather(most_recent_position, 0, senders) -
-    #     torch.gather(most_recent_position, 0, receivers)
-    # ) / self._connectivity_radius
-    normalized_relative_displacements = (
-        most_recent_position[senders, :] -
-        most_recent_position[receivers, :]
-    ) / self._connectivity_radius
+        # Relative displacement and distances normalized to radius
+        # with shape (nedges, 2)
+        # normalized_relative_displacements = (
+        #     torch.gather(most_recent_position, 0, senders) -
+        #     torch.gather(most_recent_position, 0, receivers)
+        # ) / self._connectivity_radius
+        normalized_relative_displacements = (
+            most_recent_position[senders, :] - most_recent_position[receivers, :]
+        ) / self._connectivity_radius
 
-    # Add relative displacement between two particles as an edge feature
-    # with shape (nparticles, ndim)
-    edge_features.append(normalized_relative_displacements)
+        # Add relative displacement between two particles as an edge feature
+        # with shape (nparticles, ndim)
+        edge_features.append(normalized_relative_displacements)
 
-    # Add relative distance between 2 particles with shape (nparticles, 1)
-    # Edge features has a final shape of (nparticles, ndim + 1)
-    normalized_relative_distances = torch.norm(
-        normalized_relative_displacements, dim=-1, keepdim=True)
-    edge_features.append(normalized_relative_distances)
+        # Add relative distance between 2 particles with shape (nparticles, 1)
+        # Edge features has a final shape of (nparticles, ndim + 1)
+        normalized_relative_distances = torch.norm(
+            normalized_relative_displacements, dim=-1, keepdim=True
+        )
+        edge_features.append(normalized_relative_distances)
 
-    return (torch.cat(node_features, dim=-1),
+        return (
+            torch.cat(node_features, dim=-1),
             torch.stack([senders, receivers]),
-            torch.cat(edge_features, dim=-1))
+            torch.cat(edge_features, dim=-1),
+        )
 
-  def _decoder_postprocessor(
-          self,
-          normalized_acceleration: torch.tensor,
-          position_sequence: torch.tensor) -> torch.tensor:
-    """ Compute new position based on acceleration and current position.
-    The model produces the output in normalized space so we apply inverse
-    normalization.
+    def _decoder_postprocessor(
+        self, normalized_acceleration: torch.tensor, position_sequence: torch.tensor
+    ) -> torch.tensor:
+        """Compute new position based on acceleration and current position.
+        The model produces the output in normalized space so we apply inverse
+        normalization.
+
+        Args:
+          normalized_acceleration: Normalized acceleration (nparticles, dim).
+          position_sequence: Position sequence of shape (nparticles, dim).
+
+        Returns:
+          torch.tensor: New position of the particles.
+
+        """
+        # Extract real acceleration values from normalized values
+        acceleration_stats = self._normalization_stats["acceleration"]
+        acceleration = (
+            normalized_acceleration * acceleration_stats["std"]
+        ) + acceleration_stats["mean"]
+
+        # Use an Euler integrator to go from acceleration to position, assuming
+        # a dt=1 corresponding to the size of the finite difference.
+        most_recent_position = position_sequence[:, -1]
+        most_recent_velocity = most_recent_position - position_sequence[:, -2]
+
+        # TODO: Fix dt
+        new_velocity = most_recent_velocity + acceleration  # * dt = 1
+        new_position = most_recent_position + new_velocity  # * dt = 1
+        return new_position
+
+    def predict_positions(
+        self,
+        current_positions: torch.tensor,
+        nparticles_per_example: torch.tensor,
+        particle_types: torch.tensor,
+        material_property: torch.tensor = None,
+    ) -> torch.tensor:
+        """Predict position based on acceleration.
+
+        Args:
+          current_positions: Current particle positions (nparticles, dim).
+          nparticles_per_example: Number of particles per example. Default is 2
+            examples per batch.
+          particle_types: Particle types with shape (nparticles).
+          material_property: Friction angle normalized by tan() with shape (nparticles)
+
+        Returns:
+          next_positions (torch.tensor): Next position of particles.
+        """
+        if material_property is not None:
+            node_features, edge_index, edge_features = self._encoder_preprocessor(
+                current_positions,
+                nparticles_per_example,
+                particle_types,
+                material_property,
+            )
+        else:
+            node_features, edge_index, edge_features = self._encoder_preprocessor(
+                current_positions, nparticles_per_example, particle_types
+            )
+        predicted_normalized_acceleration = self._encode_process_decode(
+            node_features, edge_index, edge_features
+        )
+        next_positions = self._decoder_postprocessor(
+            predicted_normalized_acceleration, current_positions
+        )
+        return next_positions
+
+    def predict_accelerations(
+        self,
+        next_positions: torch.tensor,
+        position_sequence_noise: torch.tensor,
+        position_sequence: torch.tensor,
+        nparticles_per_example: torch.tensor,
+        particle_types: torch.tensor,
+        material_property: torch.tensor = None,
+    ):
+        """Produces normalized and predicted acceleration targets.
+
+        Args:
+          next_positions: Tensor of shape (nparticles_in_batch, dim) with the
+            positions the model should output given the inputs.
+          position_sequence_noise: Tensor of the same shape as `position_sequence`
+            with the noise to apply to each particle.
+          position_sequence: A sequence of particle positions. Shape is
+            (nparticles, 6, dim). Includes current + last 5 positions.
+          nparticles_per_example: Number of particles per example. Default is 2
+            examples per batch.
+          particle_types: Particle types with shape (nparticles).
+          material_property: Friction angle normalized by tan() with shape (nparticles).
+
+        Returns:
+          Tensors of shape (nparticles_in_batch, dim) with the predicted and target
+            normalized accelerations.
+
+        """
+
+        # Add noise to the input position sequence.
+        noisy_position_sequence = position_sequence + position_sequence_noise
+
+        # Perform the forward pass with the noisy position sequence.
+        if material_property is not None:
+            node_features, edge_index, edge_features = self._encoder_preprocessor(
+                noisy_position_sequence,
+                nparticles_per_example,
+                particle_types,
+                material_property,
+            )
+        else:
+            node_features, edge_index, edge_features = self._encoder_preprocessor(
+                noisy_position_sequence, nparticles_per_example, particle_types
+            )
+        predicted_normalized_acceleration = self._encode_process_decode(
+            node_features, edge_index, edge_features
+        )
+
+        # Calculate the target acceleration, using an `adjusted_next_position `that
+        # is shifted by the noise in the last input position.
+        next_position_adjusted = next_positions + position_sequence_noise[:, -1]
+        target_normalized_acceleration = self._inverse_decoder_postprocessor(
+            next_position_adjusted, noisy_position_sequence
+        )
+        # As a result the inverted Euler update in the `_inverse_decoder` produces:
+        # * A target acceleration that does not explicitly correct for the noise in
+        #   the input positions, as the `next_position_adjusted` is different
+        #   from the true `next_position`.
+        # * A target acceleration that exactly corrects noise in the input velocity
+        #   since the target next velocity calculated by the inverse Euler update
+        #   as `next_position_adjusted - noisy_position_sequence[:,-1]`
+        #   matches the ground truth next velocity (noise cancels out).
+
+        return predicted_normalized_acceleration, target_normalized_acceleration
+
+    def _inverse_decoder_postprocessor(
+        self, next_position: torch.tensor, position_sequence: torch.tensor
+    ):
+        """Inverse of `_decoder_postprocessor`.
+
+        Args:
+          next_position: Tensor of shape (nparticles_in_batch, dim) with the
+            positions the model should output given the inputs.
+          position_sequence: A sequence of particle positions. Shape is
+            (nparticles, 6, dim). Includes current + last 5 positions.
+
+        Returns:
+          normalized_acceleration (torch.tensor): Normalized acceleration.
+
+        """
+        previous_position = position_sequence[:, -1]
+        previous_velocity = previous_position - position_sequence[:, -2]
+        next_velocity = next_position - previous_position
+        acceleration = next_velocity - previous_velocity
+
+        acceleration_stats = self._normalization_stats["acceleration"]
+        normalized_acceleration = (
+            acceleration - acceleration_stats["mean"]
+        ) / acceleration_stats["std"]
+        return normalized_acceleration
+
+    def save(self, path: str = "model.pt"):
+        """Save model state
+
+        Args:
+          path: Model path
+        """
+        torch.save(self.state_dict(), path)
+
+    def load(self, path: str):
+        """Load model state from file
+
+        Args:
+          path: Model path
+        """
+        self.load_state_dict(torch.load(path, map_location=torch.device("cpu")))
+
+
+def time_diff(position_sequence: torch.tensor) -> torch.tensor:
+    """Finite difference between two input position sequence
 
     Args:
-      normalized_acceleration: Normalized acceleration (nparticles, dim).
-      position_sequence: Position sequence of shape (nparticles, dim).
+      position_sequence: Input position sequence & shape(nparticles, 6 steps, dim)
 
     Returns:
-      torch.tensor: New position of the particles.
-
+      torch.tensor: Velocity sequence
     """
-    # Extract real acceleration values from normalized values
-    acceleration_stats = self._normalization_stats["acceleration"]
-    acceleration = (
-        normalized_acceleration * acceleration_stats['std']
-    ) + acceleration_stats['mean']
-
-    # Use an Euler integrator to go from acceleration to position, assuming
-    # a dt=1 corresponding to the size of the finite difference.
-    most_recent_position = position_sequence[:, -1]
-    most_recent_velocity = most_recent_position - position_sequence[:, -2]
-
-    # TODO: Fix dt
-    new_velocity = most_recent_velocity + acceleration  # * dt = 1
-    new_position = most_recent_position + new_velocity  # * dt = 1
-    return new_position
-
-  def predict_positions(
-          self,
-          current_positions: torch.tensor,
-          nparticles_per_example: torch.tensor,
-          particle_types: torch.tensor,
-          material_property: torch.tensor = None) -> torch.tensor:
-    """Predict position based on acceleration.
-
-    Args:
-      current_positions: Current particle positions (nparticles, dim).
-      nparticles_per_example: Number of particles per example. Default is 2
-        examples per batch.
-      particle_types: Particle types with shape (nparticles).
-      material_property: Friction angle normalized by tan() with shape (nparticles)
-
-    Returns:
-      next_positions (torch.tensor): Next position of particles.
-    """
-    if material_property is not None:
-        node_features, edge_index, edge_features = self._encoder_preprocessor(
-            current_positions, nparticles_per_example, particle_types, material_property)
-    else:
-        node_features, edge_index, edge_features = self._encoder_preprocessor(
-            current_positions, nparticles_per_example, particle_types)
-    predicted_normalized_acceleration = self._encode_process_decode(
-        node_features, edge_index, edge_features)
-    next_positions = self._decoder_postprocessor(
-        predicted_normalized_acceleration, current_positions)
-    return next_positions
-
-  def predict_accelerations(
-          self,
-          next_positions: torch.tensor,
-          position_sequence_noise: torch.tensor,
-          position_sequence: torch.tensor,
-          nparticles_per_example: torch.tensor,
-          particle_types: torch.tensor,
-          material_property: torch.tensor = None):
-    """Produces normalized and predicted acceleration targets.
-
-    Args:
-      next_positions: Tensor of shape (nparticles_in_batch, dim) with the
-        positions the model should output given the inputs.
-      position_sequence_noise: Tensor of the same shape as `position_sequence`
-        with the noise to apply to each particle.
-      position_sequence: A sequence of particle positions. Shape is
-        (nparticles, 6, dim). Includes current + last 5 positions.
-      nparticles_per_example: Number of particles per example. Default is 2
-        examples per batch.
-      particle_types: Particle types with shape (nparticles).
-      material_property: Friction angle normalized by tan() with shape (nparticles).
-
-    Returns:
-      Tensors of shape (nparticles_in_batch, dim) with the predicted and target
-        normalized accelerations.
-
-    """
-
-    # Add noise to the input position sequence.
-    noisy_position_sequence = position_sequence + position_sequence_noise
-
-    # Perform the forward pass with the noisy position sequence.
-    if material_property is not None:
-        node_features, edge_index, edge_features = self._encoder_preprocessor(
-            noisy_position_sequence, nparticles_per_example, particle_types, material_property)
-    else:
-        node_features, edge_index, edge_features = self._encoder_preprocessor(
-            noisy_position_sequence, nparticles_per_example, particle_types)
-    predicted_normalized_acceleration = self._encode_process_decode(
-        node_features, edge_index, edge_features)
-
-    # Calculate the target acceleration, using an `adjusted_next_position `that
-    # is shifted by the noise in the last input position.
-    next_position_adjusted = next_positions + position_sequence_noise[:, -1]
-    target_normalized_acceleration = self._inverse_decoder_postprocessor(
-        next_position_adjusted, noisy_position_sequence)
-    # As a result the inverted Euler update in the `_inverse_decoder` produces:
-    # * A target acceleration that does not explicitly correct for the noise in
-    #   the input positions, as the `next_position_adjusted` is different
-    #   from the true `next_position`.
-    # * A target acceleration that exactly corrects noise in the input velocity
-    #   since the target next velocity calculated by the inverse Euler update
-    #   as `next_position_adjusted - noisy_position_sequence[:,-1]`
-    #   matches the ground truth next velocity (noise cancels out).
-
-    return predicted_normalized_acceleration, target_normalized_acceleration
-
-  def _inverse_decoder_postprocessor(
-          self,
-          next_position: torch.tensor,
-          position_sequence: torch.tensor):
-    """Inverse of `_decoder_postprocessor`.
-
-    Args:
-      next_position: Tensor of shape (nparticles_in_batch, dim) with the
-        positions the model should output given the inputs.
-      position_sequence: A sequence of particle positions. Shape is
-        (nparticles, 6, dim). Includes current + last 5 positions.
-
-    Returns:
-      normalized_acceleration (torch.tensor): Normalized acceleration.
-
-    """
-    previous_position = position_sequence[:, -1]
-    previous_velocity = previous_position - position_sequence[:, -2]
-    next_velocity = next_position - previous_position
-    acceleration = next_velocity - previous_velocity
-
-    acceleration_stats = self._normalization_stats["acceleration"]
-    normalized_acceleration = (
-        acceleration - acceleration_stats['mean']) / acceleration_stats['std']
-    return normalized_acceleration
-
-  def save(
-          self,
-          path: str = 'model.pt'):
-    """Save model state
-
-    Args:
-      path: Model path
-    """
-    torch.save(self.state_dict(), path)
-
-  def load(
-          self,
-          path: str):
-    """Load model state from file
-
-    Args:
-      path: Model path
-    """
-    self.load_state_dict(torch.load(path, map_location=torch.device('cpu')))
-
-
-def time_diff(
-        position_sequence: torch.tensor) -> torch.tensor:
-  """Finite difference between two input position sequence
-
-  Args:
-    position_sequence: Input position sequence & shape(nparticles, 6 steps, dim)
-
-  Returns:
-    torch.tensor: Velocity sequence
-  """
-  return position_sequence[:, 1:] - position_sequence[:, :-1]
+    return position_sequence[:, 1:] - position_sequence[:, :-1]

--- a/gns/noise_utils.py
+++ b/gns/noise_utils.py
@@ -3,36 +3,41 @@ from gns import learned_simulator
 
 
 def get_random_walk_noise_for_position_sequence(
-        position_sequence: torch.tensor,
-        noise_std_last_step):
-  """Returns random-walk noise in the velocity applied to the position.
+    position_sequence: torch.tensor, noise_std_last_step
+):
+    """Returns random-walk noise in the velocity applied to the position.
 
-  Args: 
-    position_sequence: A sequence of particle positions. Shape is
-      (nparticles, 6, dim). Includes current + last 5 positions.
-    noise_std_last_step: Standard deviation of noise in the last step.
+    Args:
+      position_sequence: A sequence of particle positions. Shape is
+        (nparticles, 6, dim). Includes current + last 5 positions.
+      noise_std_last_step: Standard deviation of noise in the last step.
 
-  """
-  velocity_sequence = learned_simulator.time_diff(position_sequence)
+    """
+    velocity_sequence = learned_simulator.time_diff(position_sequence)
 
-  # We want the noise scale in the velocity at the last step to be fixed.
-  # Because we are going to compose noise at each step using a random_walk:
-  # std_last_step**2 = num_velocities * std_each_step**2
-  # so to keep `std_last_step` fixed, we apply at each step:
-  # std_each_step `std_last_step / np.sqrt(num_input_velocities)`
-  num_velocities = velocity_sequence.shape[1]
-  velocity_sequence_noise = torch.randn(
-      list(velocity_sequence.shape)) * (noise_std_last_step/num_velocities**0.5)
+    # We want the noise scale in the velocity at the last step to be fixed.
+    # Because we are going to compose noise at each step using a random_walk:
+    # std_last_step**2 = num_velocities * std_each_step**2
+    # so to keep `std_last_step` fixed, we apply at each step:
+    # std_each_step `std_last_step / np.sqrt(num_input_velocities)`
+    num_velocities = velocity_sequence.shape[1]
+    velocity_sequence_noise = torch.randn(list(velocity_sequence.shape)) * (
+        noise_std_last_step / num_velocities**0.5
+    )
 
-  # Apply the random walk.
-  velocity_sequence_noise = torch.cumsum(velocity_sequence_noise, dim=1)
+    # Apply the random walk.
+    velocity_sequence_noise = torch.cumsum(velocity_sequence_noise, dim=1)
 
-  # Integrate the noise in the velocity to the positions, assuming
-  # an Euler intergrator and a dt = 1, and adding no noise to the very first
-  # position (since that will only be used to calculate the first position
-  # change).
-  position_sequence_noise = torch.cat([
-      torch.zeros_like(velocity_sequence_noise[:, 0:1]),
-      torch.cumsum(velocity_sequence_noise, dim=1)], dim=1)
+    # Integrate the noise in the velocity to the positions, assuming
+    # an Euler intergrator and a dt = 1, and adding no noise to the very first
+    # position (since that will only be used to calculate the first position
+    # change).
+    position_sequence_noise = torch.cat(
+        [
+            torch.zeros_like(velocity_sequence_noise[:, 0:1]),
+            torch.cumsum(velocity_sequence_noise, dim=1),
+        ],
+        dim=1,
+    )
 
-  return position_sequence_noise
+    return position_sequence_noise

--- a/gns/reading_utils.py
+++ b/gns/reading_utils.py
@@ -1,34 +1,34 @@
 import os
 import json
 
-def read_metadata(data_path: str,
-                  purpose: str,
-                  file_name: str = "metadata.json"):
-  """Read metadata of datasets
 
-  Args:
-    data_path (str): Path to metadata JSON file
-    purpose (str): Optional str whether "train" or "rollout"
-    file_name (str): Name of metadata file
+def read_metadata(data_path: str, purpose: str, file_name: str = "metadata.json"):
+    """Read metadata of datasets
 
-  Returns:
-    metadata json object
-  """
-  try:
-    with open(os.path.join(data_path, file_name), 'rt') as fp:
-      # New version use separate metadata for `train` and `rollout`.
-      metadata = json.loads(fp.read())[purpose]
+    Args:
+      data_path (str): Path to metadata JSON file
+      purpose (str): Optional str whether "train" or "rollout"
+      file_name (str): Name of metadata file
 
-  except:
-    with open(os.path.join(data_path, file_name), 'rt') as fp:
-      # The previous format of the metadata does not distinguish the purpose of metadata
-      metadata = json.loads(fp.read())
+    Returns:
+      metadata json object
+    """
+    try:
+        with open(os.path.join(data_path, file_name), "rt") as fp:
+            # New version use separate metadata for `train` and `rollout`.
+            metadata = json.loads(fp.read())[purpose]
 
-  return metadata
+    except:
+        with open(os.path.join(data_path, file_name), "rt") as fp:
+            # The previous format of the metadata does not distinguish the purpose of metadata
+            metadata = json.loads(fp.read())
+
+    return metadata
+
 
 def flags_to_dict(FLAGS):
-  flags_dict = {}
-  for name in FLAGS:
-    flag_value = FLAGS[name].value
-    flags_dict[name] = flag_value
-  return flags_dict
+    flags_dict = {}
+    for name in FLAGS:
+        flag_value = FLAGS[name].value
+        flags_dict[name] = flag_value
+    return flags_dict

--- a/gns/render_rollout.py
+++ b/gns/render_rollout.py
@@ -27,7 +27,7 @@ TYPE_TO_COLOR = {
 }
 
 
-class Render():
+class Render:
     """
     Render rollout data into gif or vtk files
     """
@@ -42,7 +42,9 @@ class Render():
         """
         # Texts to describe rollout cases for data and render
         rollout_cases = [
-            ["ground_truth_rollout", "Reality"], ["predicted_rollout", "GNS"]]
+            ["ground_truth_rollout", "Reality"],
+            ["predicted_rollout", "GNS"],
+        ]
         self.rollout_cases = rollout_cases
         self.input_dir = input_dir
         self.input_name = input_name
@@ -56,10 +58,11 @@ class Render():
         trajectory = {}
         for rollout_case in rollout_cases:
             trajectory[rollout_case[0]] = np.concatenate(
-                [rollout_data["initial_positions"], rollout_data[rollout_case[0]]], axis=0
+                [rollout_data["initial_positions"], rollout_data[rollout_case[0]]],
+                axis=0,
             )
         self.trajectory = trajectory
-        self.loss = self.rollout_data['loss'].item()
+        self.loss = self.rollout_data["loss"].item()
 
         # Trajectory information
         self.dims = trajectory[rollout_cases[0][0]].shape[2]
@@ -94,7 +97,12 @@ class Render():
         return color_mask
 
     def render_gif_animation(
-            self, point_size=1, timestep_stride=3, vertical_camera_angle=20, viewpoint_rotation=0.5, change_yz=False
+        self,
+        point_size=1,
+        timestep_stride=3,
+        vertical_camera_angle=20,
+        viewpoint_rotation=0.5,
+        change_yz=False,
     ):
         """
         Render `.gif` animation from `.pkl` trajectory data.
@@ -111,12 +119,12 @@ class Render():
         # Init figures
         fig = plt.figure()
         if self.dims == 2:
-            ax1 = fig.add_subplot(1, 2, 1, projection='rectilinear')
-            ax2 = fig.add_subplot(1, 2, 2, projection='rectilinear')
+            ax1 = fig.add_subplot(1, 2, 1, projection="rectilinear")
+            ax2 = fig.add_subplot(1, 2, 2, projection="rectilinear")
             axes = [ax1, ax2]
         elif self.dims == 3:
-            ax1 = fig.add_subplot(1, 2, 1, projection='3d')
-            ax2 = fig.add_subplot(1, 2, 2, projection='3d')
+            ax1 = fig.add_subplot(1, 2, 1, projection="3d")
+            ax2 = fig.add_subplot(1, 2, 2, projection="3d")
             axes = [ax1, ax2]
 
         # Define datacase name
@@ -134,6 +142,7 @@ class Render():
 
         # Fig creating function for 2d
         if self.dims == 2:
+
             def animate(i):
                 print(f"Render step {i}/{self.num_steps}")
 
@@ -145,61 +154,95 @@ class Render():
                     axes[j].set_xlim([float(xboundary[0]), float(xboundary[1])])
                     axes[j].set_ylim([float(yboundary[0]), float(yboundary[1])])
                     for mask, color in color_mask:
-                        axes[j].scatter(self.trajectory[datacase][i][mask, 0],
-                                        self.trajectory[datacase][i][mask, 1], s=point_size, color=color)
-                    axes[j].grid(True, which='both')
+                        axes[j].scatter(
+                            self.trajectory[datacase][i][mask, 0],
+                            self.trajectory[datacase][i][mask, 1],
+                            s=point_size,
+                            color=color,
+                        )
+                    axes[j].grid(True, which="both")
                     axes[j].set_title(render_datacases[j])
                 fig.suptitle(f"{i}/{self.num_steps}, Total MSE: {self.loss:.2e}")
 
         # Fig creating function for 3d
         elif self.dims == 3:
+
             def animate(i):
                 print(f"Render step {i}/{self.num_steps} for {self.output_name}")
 
                 fig.clear()
                 for j, datacase in enumerate(trajectory_datacases):
                     # select ax to plot at set boundary
-                    axes[j] = fig.add_subplot(1, 2, j + 1, projection='3d', autoscale_on=False)
+                    axes[j] = fig.add_subplot(
+                        1, 2, j + 1, projection="3d", autoscale_on=False
+                    )
                     if change_yz == False:
                         axes[j].set_xlim([float(xboundary[0]), float(xboundary[1])])
                         axes[j].set_ylim([float(yboundary[0]), float(yboundary[1])])
                         axes[j].set_zlim([float(zboundary[0]), float(zboundary[1])])
                         for mask, color in color_mask:
-                            axes[j].scatter(self.trajectory[datacase][i][mask, 0],
-                                            self.trajectory[datacase][i][mask, 1],
-                                            self.trajectory[datacase][i][mask, 2], s=point_size, color=color)
+                            axes[j].scatter(
+                                self.trajectory[datacase][i][mask, 0],
+                                self.trajectory[datacase][i][mask, 1],
+                                self.trajectory[datacase][i][mask, 2],
+                                s=point_size,
+                                color=color,
+                            )
                         # rotate viewpoints angle little by little for each timestep
                         axes[j].set_box_aspect(
-                            aspect=(float(xboundary[1]) - float(xboundary[0]),
-                                    float(yboundary[1]) - float(yboundary[0]),
-                                    float(zboundary[1]) - float(zboundary[0])))
-                        axes[j].view_init(elev=vertical_camera_angle, azim=i * viewpoint_rotation)
-                        axes[j].grid(True, which='both')
+                            aspect=(
+                                float(xboundary[1]) - float(xboundary[0]),
+                                float(yboundary[1]) - float(yboundary[0]),
+                                float(zboundary[1]) - float(zboundary[0]),
+                            )
+                        )
+                        axes[j].view_init(
+                            elev=vertical_camera_angle, azim=i * viewpoint_rotation
+                        )
+                        axes[j].grid(True, which="both")
                         axes[j].set_title(render_datacases[j])
                     else:
                         axes[j].set_xlim([float(xboundary[0]), float(xboundary[1])])
                         axes[j].set_ylim([float(zboundary[0]), float(zboundary[1])])
                         axes[j].set_zlim([float(yboundary[0]), float(yboundary[1])])
                         for mask, color in color_mask:
-                            axes[j].scatter(self.trajectory[datacase][i][mask, 0],
-                                            self.trajectory[datacase][i][mask, 2],
-                                            self.trajectory[datacase][i][mask, 1], s=point_size, color=color)
+                            axes[j].scatter(
+                                self.trajectory[datacase][i][mask, 0],
+                                self.trajectory[datacase][i][mask, 2],
+                                self.trajectory[datacase][i][mask, 1],
+                                s=point_size,
+                                color=color,
+                            )
                         # set aspect ratio to equal
                         axes[j].set_box_aspect(
-                            aspect=(float(xboundary[1]) - float(xboundary[0]),
-                                    float(zboundary[1]) - float(zboundary[0]),
-                                    float(yboundary[1]) - float(yboundary[0])))
+                            aspect=(
+                                float(xboundary[1]) - float(xboundary[0]),
+                                float(zboundary[1]) - float(zboundary[0]),
+                                float(yboundary[1]) - float(yboundary[0]),
+                            )
+                        )
                         # rotate viewpoints angle little by little for each timestep
-                        axes[j].view_init(elev=vertical_camera_angle, azim=i * viewpoint_rotation)
-                        axes[j].grid(True, which='both')
+                        axes[j].view_init(
+                            elev=vertical_camera_angle, azim=i * viewpoint_rotation
+                        )
+                        axes[j].grid(True, which="both")
                         axes[j].set_title(render_datacases[j])
                 fig.suptitle(f"{i}/{self.num_steps}, Total MSE: {self.loss:.2e}")
 
         # Creat animation
         ani = animation.FuncAnimation(
-            fig, animate, frames=np.arange(0, self.num_steps, timestep_stride), interval=10)
+            fig,
+            animate,
+            frames=np.arange(0, self.num_steps, timestep_stride),
+            interval=10,
+        )
 
-        ani.save(f'{self.output_dir}{self.output_name}.gif', dpi=100, fps=30, writer='imagemagick')
+        ani.save(
+            f"{self.output_dir}{self.output_name}.gif",
+            dpi=100,
+            fps=30,
+            writer="imagemagick",
+        )
         print(f"Animation saved to: {self.output_dir}{self.output_name}.gif")
 
     def write_vtk(self):
@@ -213,11 +256,15 @@ class Render():
             initial_position = self.trajectory[rollout_case][0]
             for i, coord in enumerate(self.trajectory[rollout_case]):
                 disp = np.linalg.norm(coord - initial_position, axis=1)
-                pointsToVTK(f"{path}/points{i}",
-                            np.array(coord[:, 0]),
-                            np.array(coord[:, 1]),
-                            np.zeros_like(coord[:, 1]) if self.dims == 2 else np.array(coord[:, 2]),
-                            data={"displacement": disp})
+                pointsToVTK(
+                    f"{path}/points{i}",
+                    np.array(coord[:, 0]),
+                    np.array(coord[:, 1]),
+                    np.zeros_like(coord[:, 1])
+                    if self.dims == 2
+                    else np.array(coord[:, 2]),
+                    data={"displacement": disp},
+                )
         print(f"vtk saved to: {self.output_dir}{self.output_name}...")
 
 
@@ -235,12 +282,11 @@ def main(_):
             timestep_stride=FLAGS.step_stride,
             vertical_camera_angle=20,
             viewpoint_rotation=0.3,
-            change_yz=FLAGS.change_yz
+            change_yz=FLAGS.change_yz,
         )
     elif FLAGS.output_mode == "vtk":
         render.write_vtk()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(main)
-

--- a/gns/train.py
+++ b/gns/train.py
@@ -476,6 +476,9 @@ def train(rank, flags, world_size, device):
     if rank == 0 or device == torch.device("cpu"):
         writer = SummaryWriter(log_dir=flags["tensorboard_log_dir"])
 
+        writer.add_text("Data path", flags["data_path"])
+        writer.add_text("metadata", json.dumps(metadata, indent=4))
+        
         # Log hyperparameters
         hparam_dict = {
             "lr_init": flags["lr_init"],

--- a/gns/train.py
+++ b/gns/train.py
@@ -389,7 +389,7 @@ def train(rank, flags, world_size, device):
     steps_per_epoch = 0
 
     valid_loss = None
-    epoch_train_loss = 0
+    train_loss = 0
     epoch_valid_loss = None
 
     train_loss_hist = []

--- a/gns/train.py
+++ b/gns/train.py
@@ -478,7 +478,7 @@ def train(rank, flags, world_size, device):
 
         writer.add_text("Data path", flags["data_path"])
         writer.add_text("metadata", json.dumps(metadata, indent=4))
-        
+
         # Log hyperparameters
         hparam_dict = {
             "lr_init": flags["lr_init"],

--- a/gns/train.py
+++ b/gns/train.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from absl import flags
 from absl import app
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from gns import learned_simulator
 from gns import noise_utils
 from gns import reading_utils
@@ -22,637 +22,784 @@ from gns import data_loader
 from gns import distribute
 
 flags.DEFINE_enum(
-    'mode', 'train', ['train', 'valid', 'rollout'],
-    help='Train model, validation or rollout evaluation.')
-flags.DEFINE_integer('batch_size', 2, help='The batch size.')
-flags.DEFINE_float('noise_std', 6.7e-4, help='The std deviation of the noise.')
-flags.DEFINE_string('data_path', None, help='The dataset directory.')
-flags.DEFINE_string('model_path', 'models/', help=('The path for saving checkpoints of the model.'))
-flags.DEFINE_string('output_path', 'rollouts/', help='The path for saving outputs (e.g. rollouts).')
-flags.DEFINE_string('output_filename', 'rollout', help='Base name for saving the rollout')
-flags.DEFINE_string('model_file', None, help=('Model filename (.pt) to resume from. Can also use "latest" to default to newest file.'))
-flags.DEFINE_string('train_state_file', 'train_state.pt', help=('Train state filename (.pt) to resume from. Can also use "latest" to default to newest file.'))
+    "mode",
+    "train",
+    ["train", "valid", "rollout"],
+    help="Train model, validation or rollout evaluation.",
+)
+flags.DEFINE_integer("batch_size", 2, help="The batch size.")
+flags.DEFINE_float("noise_std", 6.7e-4, help="The std deviation of the noise.")
+flags.DEFINE_string("data_path", None, help="The dataset directory.")
+flags.DEFINE_string(
+    "model_path", "models/", help=("The path for saving checkpoints of the model.")
+)
+flags.DEFINE_string(
+    "output_path", "rollouts/", help="The path for saving outputs (e.g. rollouts)."
+)
+flags.DEFINE_string(
+    "output_filename", "rollout", help="Base name for saving the rollout"
+)
+flags.DEFINE_string(
+    "model_file",
+    None,
+    help=(
+        'Model filename (.pt) to resume from. Can also use "latest" to default to newest file.'
+    ),
+)
+flags.DEFINE_string(
+    "train_state_file",
+    "train_state.pt",
+    help=(
+        'Train state filename (.pt) to resume from. Can also use "latest" to default to newest file.'
+    ),
+)
 
-flags.DEFINE_integer('ntraining_steps', int(2E7), help='Number of training steps.')
-flags.DEFINE_integer('validation_interval', None, help='Validation interval. Set `None` if validation loss is not needed')
-flags.DEFINE_integer('nsave_steps', int(5000), help='Number of steps at which to save the model.')
+flags.DEFINE_integer("ntraining_steps", int(2e7), help="Number of training steps.")
+flags.DEFINE_integer(
+    "validation_interval",
+    None,
+    help="Validation interval. Set `None` if validation loss is not needed",
+)
+flags.DEFINE_integer(
+    "nsave_steps", int(5000), help="Number of steps at which to save the model."
+)
 
 # Learning rate parameters
-flags.DEFINE_float('lr_init', 1e-4, help='Initial learning rate.')
-flags.DEFINE_float('lr_decay', 0.1, help='Learning rate decay.')
-flags.DEFINE_integer('lr_decay_steps', int(5e6), help='Learning rate decay steps.')
+flags.DEFINE_float("lr_init", 1e-4, help="Initial learning rate.")
+flags.DEFINE_float("lr_decay", 0.1, help="Learning rate decay.")
+flags.DEFINE_integer("lr_decay_steps", int(5e6), help="Learning rate decay steps.")
 
-flags.DEFINE_integer("cuda_device_number", None, help="CUDA device (zero indexed), default is None so default CUDA device will be used.")
+flags.DEFINE_integer(
+    "cuda_device_number",
+    None,
+    help="CUDA device (zero indexed), default is None so default CUDA device will be used.",
+)
 flags.DEFINE_integer("n_gpus", 1, help="The number of GPUs to utilize for training.")
 
 FLAGS = flags.FLAGS
 
-Stats = collections.namedtuple('Stats', ['mean', 'std'])
+Stats = collections.namedtuple("Stats", ["mean", "std"])
 
 INPUT_SEQUENCE_LENGTH = 6  # So we can calculate the last 5 velocities.
 NUM_PARTICLE_TYPES = 9
 KINEMATIC_PARTICLE_ID = 3
 
+
 def rollout(
-        simulator: learned_simulator.LearnedSimulator,
-        position: torch.tensor,
-        particle_types: torch.tensor,
-        material_property: torch.tensor,
-        n_particles_per_example: torch.tensor,
-        nsteps: int,
-        device: torch.device):
-  """
-  Rolls out a trajectory by applying the model in sequence.
+    simulator: learned_simulator.LearnedSimulator,
+    position: torch.tensor,
+    particle_types: torch.tensor,
+    material_property: torch.tensor,
+    n_particles_per_example: torch.tensor,
+    nsteps: int,
+    device: torch.device,
+):
+    """
+    Rolls out a trajectory by applying the model in sequence.
 
-  Args:
-    simulator: Learned simulator.
-    position: Positions of particles (timesteps, nparticles, ndims)
-    particle_types: Particles types with shape (nparticles)
-    material_property: Friction angle normalized by tan() with shape (nparticles)
-    n_particles_per_example
-    nsteps: Number of steps.
-    device: torch device.
-  """
+    Args:
+      simulator: Learned simulator.
+      position: Positions of particles (timesteps, nparticles, ndims)
+      particle_types: Particles types with shape (nparticles)
+      material_property: Friction angle normalized by tan() with shape (nparticles)
+      n_particles_per_example
+      nsteps: Number of steps.
+      device: torch device.
+    """
 
-  initial_positions = position[:, :INPUT_SEQUENCE_LENGTH]
-  ground_truth_positions = position[:, INPUT_SEQUENCE_LENGTH:]
+    initial_positions = position[:, :INPUT_SEQUENCE_LENGTH]
+    ground_truth_positions = position[:, INPUT_SEQUENCE_LENGTH:]
 
-  current_positions = initial_positions
-  predictions = []
+    current_positions = initial_positions
+    predictions = []
 
-  for step in tqdm(range(nsteps), total=nsteps):
-    # Get next position with shape (nnodes, dim)
-    next_position = simulator.predict_positions(
-        current_positions,
-        nparticles_per_example=[n_particles_per_example],
-        particle_types=particle_types,
-        material_property=material_property
-    )
+    for step in tqdm(range(nsteps), total=nsteps):
+        # Get next position with shape (nnodes, dim)
+        next_position = simulator.predict_positions(
+            current_positions,
+            nparticles_per_example=[n_particles_per_example],
+            particle_types=particle_types,
+            material_property=material_property,
+        )
 
-    # Update kinematic particles from prescribed trajectory.
-    kinematic_mask = (particle_types == KINEMATIC_PARTICLE_ID).clone().detach().to(device)
-    next_position_ground_truth = ground_truth_positions[:, step]
-    kinematic_mask = kinematic_mask.bool()[:, None].expand(-1, current_positions.shape[-1])
-    next_position = torch.where(
-        kinematic_mask, next_position_ground_truth, next_position)
-    predictions.append(next_position)
+        # Update kinematic particles from prescribed trajectory.
+        kinematic_mask = (
+            (particle_types == KINEMATIC_PARTICLE_ID).clone().detach().to(device)
+        )
+        next_position_ground_truth = ground_truth_positions[:, step]
+        kinematic_mask = kinematic_mask.bool()[:, None].expand(
+            -1, current_positions.shape[-1]
+        )
+        next_position = torch.where(
+            kinematic_mask, next_position_ground_truth, next_position
+        )
+        predictions.append(next_position)
 
-    # Shift `current_positions`, removing the oldest position in the sequence
-    # and appending the next position at the end.
-    current_positions = torch.cat(
-        [current_positions[:, 1:], next_position[:, None, :]], dim=1)
+        # Shift `current_positions`, removing the oldest position in the sequence
+        # and appending the next position at the end.
+        current_positions = torch.cat(
+            [current_positions[:, 1:], next_position[:, None, :]], dim=1
+        )
 
-  # Predictions with shape (time, nnodes, dim)
-  predictions = torch.stack(predictions)
-  ground_truth_positions = ground_truth_positions.permute(1, 0, 2)
+    # Predictions with shape (time, nnodes, dim)
+    predictions = torch.stack(predictions)
+    ground_truth_positions = ground_truth_positions.permute(1, 0, 2)
 
-  loss = (predictions - ground_truth_positions) ** 2
+    loss = (predictions - ground_truth_positions) ** 2
 
-  output_dict = {
-      'initial_positions': initial_positions.permute(1, 0, 2).cpu().numpy(),
-      'predicted_rollout': predictions.cpu().numpy(),
-      'ground_truth_rollout': ground_truth_positions.cpu().numpy(),
-      'particle_types': particle_types.cpu().numpy(),
-      'material_property': material_property.cpu().numpy() if material_property is not None else None
-  }
+    output_dict = {
+        "initial_positions": initial_positions.permute(1, 0, 2).cpu().numpy(),
+        "predicted_rollout": predictions.cpu().numpy(),
+        "ground_truth_rollout": ground_truth_positions.cpu().numpy(),
+        "particle_types": particle_types.cpu().numpy(),
+        "material_property": material_property.cpu().numpy()
+        if material_property is not None
+        else None,
+    }
 
-  return output_dict, loss
+    return output_dict, loss
 
 
 def predict(device: str):
-  """Predict rollouts.
+    """Predict rollouts.
 
-  Args:
-    simulator: Trained simulator if not will undergo training.
+    Args:
+      simulator: Trained simulator if not will undergo training.
 
-  """
-  # Read metadata
-  metadata = reading_utils.read_metadata(FLAGS.data_path, "rollout")
-  simulator = _get_simulator(metadata, FLAGS.noise_std, FLAGS.noise_std, device)
+    """
+    # Read metadata
+    metadata = reading_utils.read_metadata(FLAGS.data_path, "rollout")
+    simulator = _get_simulator(metadata, FLAGS.noise_std, FLAGS.noise_std, device)
 
-  # Load simulator
-  if os.path.exists(FLAGS.model_path + FLAGS.model_file):
-    simulator.load(FLAGS.model_path + FLAGS.model_file)
-  else:
-    raise Exception(f"Model does not exist at {FLAGS.model_path + FLAGS.model_file}")
+    # Load simulator
+    if os.path.exists(FLAGS.model_path + FLAGS.model_file):
+        simulator.load(FLAGS.model_path + FLAGS.model_file)
+    else:
+        raise Exception(
+            f"Model does not exist at {FLAGS.model_path + FLAGS.model_file}"
+        )
 
-  simulator.to(device)
-  simulator.eval()
+    simulator.to(device)
+    simulator.eval()
 
-  # Output path
-  if not os.path.exists(FLAGS.output_path):
-    os.makedirs(FLAGS.output_path)
+    # Output path
+    if not os.path.exists(FLAGS.output_path):
+        os.makedirs(FLAGS.output_path)
 
-  # Use `valid`` set for eval mode if not use `test`
-  split = 'test' if (FLAGS.mode == 'rollout' or (not os.path.isfile("{FLAGS.data_path}valid.npz"))) else 'valid'
+    # Use `valid`` set for eval mode if not use `test`
+    split = (
+        "test"
+        if (
+            FLAGS.mode == "rollout"
+            or (not os.path.isfile("{FLAGS.data_path}valid.npz"))
+        )
+        else "valid"
+    )
 
-  # Get dataset
-  ds = data_loader.get_data_loader_by_trajectories(path=f"{FLAGS.data_path}{split}.npz")
-  # See if our dataset has material property as feature
-  if len(ds.dataset._data[0]) == 3:  # `ds` has (positions, particle_type, material_property)
-    material_property_as_feature = True
-  elif len(ds.dataset._data[0]) == 2:  # `ds` only has (positions, particle_type)
-    material_property_as_feature = False
-  else:
-    raise NotImplementedError
+    # Get dataset
+    ds = data_loader.get_data_loader_by_trajectories(
+        path=f"{FLAGS.data_path}{split}.npz"
+    )
+    # See if our dataset has material property as feature
+    if (
+        len(ds.dataset._data[0]) == 3
+    ):  # `ds` has (positions, particle_type, material_property)
+        material_property_as_feature = True
+    elif len(ds.dataset._data[0]) == 2:  # `ds` only has (positions, particle_type)
+        material_property_as_feature = False
+    else:
+        raise NotImplementedError
 
-  eval_loss = []
-  with torch.no_grad():
-    for example_i, features in enumerate(ds):
-      print(f"processing example number {example_i}")
-      positions = features[0].to(device)
-      if metadata['sequence_length'] is not None:
-        # If `sequence_length` is predefined in metadata,
-        nsteps = metadata['sequence_length'] - INPUT_SEQUENCE_LENGTH
-      else:
-        # If no predefined `sequence_length`, then get the sequence length
-        sequence_length = positions.shape[1]
-        nsteps = sequence_length - INPUT_SEQUENCE_LENGTH
-      particle_type = features[1].to(device)
-      if material_property_as_feature:
-        material_property = features[2].to(device)
-        n_particles_per_example = torch.tensor([int(features[3])], dtype=torch.int32).to(device)
-      else:
-        material_property = None
-        n_particles_per_example = torch.tensor([int(features[2])], dtype=torch.int32).to(device)
+    eval_loss = []
+    with torch.no_grad():
+        for example_i, features in enumerate(ds):
+            print(f"processing example number {example_i}")
+            positions = features[0].to(device)
+            if metadata["sequence_length"] is not None:
+                # If `sequence_length` is predefined in metadata,
+                nsteps = metadata["sequence_length"] - INPUT_SEQUENCE_LENGTH
+            else:
+                # If no predefined `sequence_length`, then get the sequence length
+                sequence_length = positions.shape[1]
+                nsteps = sequence_length - INPUT_SEQUENCE_LENGTH
+            particle_type = features[1].to(device)
+            if material_property_as_feature:
+                material_property = features[2].to(device)
+                n_particles_per_example = torch.tensor(
+                    [int(features[3])], dtype=torch.int32
+                ).to(device)
+            else:
+                material_property = None
+                n_particles_per_example = torch.tensor(
+                    [int(features[2])], dtype=torch.int32
+                ).to(device)
 
-      # Predict example rollout
-      example_rollout, loss = rollout(simulator,
-                                      positions,
-                                      particle_type,
-                                      material_property,
-                                      n_particles_per_example,
-                                      nsteps,
-                                      device)
+            # Predict example rollout
+            example_rollout, loss = rollout(
+                simulator,
+                positions,
+                particle_type,
+                material_property,
+                n_particles_per_example,
+                nsteps,
+                device,
+            )
 
-      example_rollout['metadata'] = metadata
-      print("Predicting example {} loss: {}".format(example_i, loss.mean()))
-      eval_loss.append(torch.flatten(loss))
+            example_rollout["metadata"] = metadata
+            print("Predicting example {} loss: {}".format(example_i, loss.mean()))
+            eval_loss.append(torch.flatten(loss))
 
-      # Save rollout in testing
-      if FLAGS.mode == 'rollout':
-        example_rollout['metadata'] = metadata
-        example_rollout['loss'] = loss.mean()
-        filename = f'{FLAGS.output_filename}_ex{example_i}.pkl'
-        filename = os.path.join(FLAGS.output_path, filename)
-        with open(filename, 'wb') as f:
-          pickle.dump(example_rollout, f)
+            # Save rollout in testing
+            if FLAGS.mode == "rollout":
+                example_rollout["metadata"] = metadata
+                example_rollout["loss"] = loss.mean()
+                filename = f"{FLAGS.output_filename}_ex{example_i}.pkl"
+                filename = os.path.join(FLAGS.output_path, filename)
+                with open(filename, "wb") as f:
+                    pickle.dump(example_rollout, f)
 
-  print("Mean loss on rollout prediction: {}".format(
-      torch.mean(torch.cat(eval_loss))))
+    print(
+        "Mean loss on rollout prediction: {}".format(torch.mean(torch.cat(eval_loss)))
+    )
 
 
 def optimizer_to(optim, device):
-  for param in optim.state.values():
-    # Not sure there are any global tensors in the state dict
-    if isinstance(param, torch.Tensor):
-      param.data = param.data.to(device)
-      if param._grad is not None:
-        param._grad.data = param._grad.data.to(device)
-    elif isinstance(param, dict):
-      for subparam in param.values():
-        if isinstance(subparam, torch.Tensor):
-          subparam.data = subparam.data.to(device)
-          if subparam._grad is not None:
-            subparam._grad.data = subparam._grad.data.to(device)
+    for param in optim.state.values():
+        # Not sure there are any global tensors in the state dict
+        if isinstance(param, torch.Tensor):
+            param.data = param.data.to(device)
+            if param._grad is not None:
+                param._grad.data = param._grad.data.to(device)
+        elif isinstance(param, dict):
+            for subparam in param.values():
+                if isinstance(subparam, torch.Tensor):
+                    subparam.data = subparam.data.to(device)
+                    if subparam._grad is not None:
+                        subparam._grad.data = subparam._grad.data.to(device)
+
 
 def acceleration_loss(pred_acc, target_acc, non_kinematic_mask):
-  """
-  Compute the loss between predicted and target accelerations.
+    """
+    Compute the loss between predicted and target accelerations.
 
-  Args:
-    pred_acc: Predicted accelerations.
-    target_acc: Target accelerations.
-    non_kinematic_mask: Mask for kinematic particles.
-  """
-  loss = (pred_acc - target_acc) ** 2
-  loss = loss.sum(dim=-1)
-  num_non_kinematic = non_kinematic_mask.sum()
-  loss = torch.where(non_kinematic_mask.bool(),
-                    loss, torch.zeros_like(loss))
-  loss = loss.sum() / num_non_kinematic
-  return loss
+    Args:
+      pred_acc: Predicted accelerations.
+      target_acc: Target accelerations.
+      non_kinematic_mask: Mask for kinematic particles.
+    """
+    loss = (pred_acc - target_acc) ** 2
+    loss = loss.sum(dim=-1)
+    num_non_kinematic = non_kinematic_mask.sum()
+    loss = torch.where(non_kinematic_mask.bool(), loss, torch.zeros_like(loss))
+    loss = loss.sum() / num_non_kinematic
+    return loss
 
-def save_model_and_train_state(rank, device, simulator, flags, step, epoch, optimizer,
-                                train_loss, valid_loss, train_loss_hist, valid_loss_hist):
-  """Save model state
-  
-  Args:
-    rank: local rank
-    device: torch device type
-    simulator: Trained simulator if not will undergo training.
-    flags: flags
-    step: step
-    epoch: epoch
-    optimizer: optimizer
-    train_loss: training loss at current step
-    valid_loss: validation loss at current step
-    train_loss_hist: training loss history at each epoch
-    valid_loss_hist: validation loss history at each epoch
-  """
-  if rank == 0 or device == torch.device("cpu"):
-      if device == torch.device("cpu"):
-          simulator.save(flags["model_path"] + 'model-' + str(step) + '.pt')
-      else:
-          simulator.module.save(flags["model_path"] + 'model-' + str(step) + '.pt')
 
-      train_state = dict(optimizer_state=optimizer.state_dict(),
-                          global_train_state={
-                            "step": step, 
-                            "epoch": epoch,
-                            "train_loss": train_loss,
-                            "valid_loss": valid_loss
-                            },
-                          loss_history={"train": train_loss_hist, "valid": valid_loss_hist}
-                          )
-      torch.save(train_state, f'{flags["model_path"]}train_state-{step}.pt')
-      
-def train(rank, flags, world_size, device):
-  """Train the model.
+def save_model_and_train_state(
+    rank,
+    device,
+    simulator,
+    flags,
+    step,
+    epoch,
+    optimizer,
+    train_loss,
+    valid_loss,
+    train_loss_hist,
+    valid_loss_hist,
+):
+    """Save model state
 
-  Args:
-    rank: local rank
-    world_size: total number of ranks
-    device: torch device type
-  """
-  if device == torch.device("cuda"):
-    distribute.setup(rank, world_size, device)
-    device_id = rank
-  else:
-    device_id = device
-
-  # Read metadata
-  metadata = reading_utils.read_metadata(flags["data_path"], "train")
-
-  # Get simulator and optimizer
-  if device == torch.device("cuda"):
-    serial_simulator = _get_simulator(metadata, flags["noise_std"], flags["noise_std"], rank)
-    simulator = DDP(serial_simulator.to(rank), device_ids=[rank], output_device=rank)
-    optimizer = torch.optim.Adam(simulator.parameters(), lr=flags["lr_init"]*world_size)
-  else:
-    simulator = _get_simulator(metadata, flags["noise_std"], flags["noise_std"], device)
-    optimizer = torch.optim.Adam(simulator.parameters(), lr=flags["lr_init"] * world_size)
-
-  # Initialize training state
-  step = 0
-  epoch = 0
-  steps_per_epoch = 0
-
-  valid_loss = None
-  epoch_train_loss = 0
-  epoch_valid_loss = None
-
-  train_loss_hist = []
-  valid_loss_hist = []
-
-  # If model_path does exist and model_file and train_state_file exist continue training.
-  if flags["model_file"] is not None:
-
-    if flags["model_file"] == "latest" and flags["train_state_file"] == "latest":
-      # find the latest model, assumes model and train_state files are in step.
-      fnames = glob.glob(f'{flags["model_path"]}*model*pt')
-      max_model_number = 0
-      expr = re.compile(".*model-(\d+).pt")
-      for fname in fnames:
-        model_num = int(expr.search(fname).groups()[0])
-        if model_num > max_model_number:
-          max_model_number = model_num
-      # reset names to point to the latest.
-      flags["model_file"] = f"model-{max_model_number}.pt"
-      flags["train_state_file"] = f"train_state-{max_model_number}.pt"
-
-    if os.path.exists(flags["model_path"] + flags["model_file"]) and os.path.exists(flags["model_path"] + flags["train_state_file"]):
-      # load model
-      if device == torch.device("cuda"):
-        simulator.module.load(flags["model_path"] + flags["model_file"])
-      else:
-        simulator.load(flags["model_path"] + flags["model_file"])
-
-      # load train state
-      train_state = torch.load(flags["model_path"] + flags["train_state_file"])
-      
-      # set optimizer state
-      optimizer = torch.optim.Adam(
-        simulator.module.parameters() if device == torch.device("cuda") else simulator.parameters())
-      optimizer.load_state_dict(train_state["optimizer_state"])
-      optimizer_to(optimizer, device_id)
-      
-      # set global train state
-      step = train_state["global_train_state"]["step"]
-      epoch = train_state["global_train_state"]["epoch"]
-      train_loss_hist = train_state["loss_history"]["train"]
-      valid_loss_hist = train_state["loss_history"]["valid"]
-
-    else:
-      msg = f'Specified model_file {flags["model_path"] + flags["model_file"]} and train_state_file {flags["model_path"] + flags["train_state_file"]} not found.'
-      raise FileNotFoundError(msg)
-
-  simulator.train()
-  simulator.to(device_id)
-
-  # Get data loader
-  get_data_loader = (
-    distribute.get_data_distributed_dataloader_by_samples
-    if device == torch.device("cuda")
-    else data_loader.get_data_loader_by_samples
-  )
-
-  # Load training data
-  dl = get_data_loader(
-      path=f'{flags["data_path"]}train.npz',
-      input_length_sequence=INPUT_SEQUENCE_LENGTH,
-      batch_size=flags["batch_size"],
-  )
-  n_features = len(dl.dataset._data[0])
-
-  # Load validation data
-  if flags["validation_interval"] is not None:
-      dl_valid = get_data_loader(
-          path=f'{flags["data_path"]}valid.npz',
-          input_length_sequence=INPUT_SEQUENCE_LENGTH,
-          batch_size=flags["batch_size"],
-      )
-      if len(dl_valid.dataset._data[0]) != n_features:
-          raise ValueError(
-              f"`n_features` of `valid.npz` and `train.npz` should be the same"
-          )
-
-  print(f"rank = {rank}, cuda = {torch.cuda.is_available()}")
-
-  try:
-    while step < flags["ntraining_steps"]:
-      if device == torch.device("cuda"):
-        torch.distributed.barrier()
-
-      for example in dl:  
-        steps_per_epoch += 1
-        # ((position, particle_type, material_property, n_particles_per_example), labels) are in dl
-        position = example[0][0].to(device_id)
-        particle_type = example[0][1].to(device_id)
-        if n_features == 3:  # if dl includes material_property
-          material_property = example[0][2].to(device_id)
-          n_particles_per_example = example[0][3].to(device_id)
-        elif n_features == 2:
-          n_particles_per_example = example[0][2].to(device_id)
+    Args:
+      rank: local rank
+      device: torch device type
+      simulator: Trained simulator if not will undergo training.
+      flags: flags
+      step: step
+      epoch: epoch
+      optimizer: optimizer
+      train_loss: training loss at current step
+      valid_loss: validation loss at current step
+      train_loss_hist: training loss history at each epoch
+      valid_loss_hist: validation loss history at each epoch
+    """
+    if rank == 0 or device == torch.device("cpu"):
+        if device == torch.device("cpu"):
+            simulator.save(flags["model_path"] + "model-" + str(step) + ".pt")
         else:
-          raise NotImplementedError
-        labels = example[1].to(device_id)
+            simulator.module.save(flags["model_path"] + "model-" + str(step) + ".pt")
 
-        n_particles_per_example.to(device_id)
-        labels.to(device_id)
+        train_state = dict(
+            optimizer_state=optimizer.state_dict(),
+            global_train_state={
+                "step": step,
+                "epoch": epoch,
+                "train_loss": train_loss,
+                "valid_loss": valid_loss,
+            },
+            loss_history={"train": train_loss_hist, "valid": valid_loss_hist},
+        )
+        torch.save(train_state, f'{flags["model_path"]}train_state-{step}.pt')
 
-        # TODO (jpv): Move noise addition to data_loader
-        # Sample the noise to add to the inputs to the model during training.
-        sampled_noise = noise_utils.get_random_walk_noise_for_position_sequence(position, noise_std_last_step=flags["noise_std"]).to(device_id)
-        non_kinematic_mask = (particle_type != KINEMATIC_PARTICLE_ID).clone().detach().to(device_id)
-        sampled_noise *= non_kinematic_mask.view(-1, 1, 1)
 
-        # Get the predictions and target accelerations
-        device_or_rank = rank if device == torch.device("cuda") else device
-        pred_acc, target_acc = (simulator.module.predict_accelerations if device == torch.device("cuda") else simulator.predict_accelerations)(
+def train(rank, flags, world_size, device):
+    """Train the model.
+
+    Args:
+      rank: local rank
+      world_size: total number of ranks
+      device: torch device type
+    """
+    if device == torch.device("cuda"):
+        distribute.setup(rank, world_size, device)
+        device_id = rank
+    else:
+        device_id = device
+
+    # Read metadata
+    metadata = reading_utils.read_metadata(flags["data_path"], "train")
+
+    # Get simulator and optimizer
+    if device == torch.device("cuda"):
+        serial_simulator = _get_simulator(
+            metadata, flags["noise_std"], flags["noise_std"], rank
+        )
+        simulator = DDP(
+            serial_simulator.to(rank), device_ids=[rank], output_device=rank
+        )
+        optimizer = torch.optim.Adam(
+            simulator.parameters(), lr=flags["lr_init"] * world_size
+        )
+    else:
+        simulator = _get_simulator(
+            metadata, flags["noise_std"], flags["noise_std"], device
+        )
+        optimizer = torch.optim.Adam(
+            simulator.parameters(), lr=flags["lr_init"] * world_size
+        )
+
+    # Initialize training state
+    step = 0
+    epoch = 0
+    steps_per_epoch = 0
+
+    valid_loss = None
+    epoch_train_loss = 0
+    epoch_valid_loss = None
+
+    train_loss_hist = []
+    valid_loss_hist = []
+
+    # If model_path does exist and model_file and train_state_file exist continue training.
+    if flags["model_file"] is not None:
+        if flags["model_file"] == "latest" and flags["train_state_file"] == "latest":
+            # find the latest model, assumes model and train_state files are in step.
+            fnames = glob.glob(f'{flags["model_path"]}*model*pt')
+            max_model_number = 0
+            expr = re.compile(".*model-(\d+).pt")
+            for fname in fnames:
+                model_num = int(expr.search(fname).groups()[0])
+                if model_num > max_model_number:
+                    max_model_number = model_num
+            # reset names to point to the latest.
+            flags["model_file"] = f"model-{max_model_number}.pt"
+            flags["train_state_file"] = f"train_state-{max_model_number}.pt"
+
+        if os.path.exists(flags["model_path"] + flags["model_file"]) and os.path.exists(
+            flags["model_path"] + flags["train_state_file"]
+        ):
+            # load model
+            if device == torch.device("cuda"):
+                simulator.module.load(flags["model_path"] + flags["model_file"])
+            else:
+                simulator.load(flags["model_path"] + flags["model_file"])
+
+            # load train state
+            train_state = torch.load(flags["model_path"] + flags["train_state_file"])
+
+            # set optimizer state
+            optimizer = torch.optim.Adam(
+                simulator.module.parameters()
+                if device == torch.device("cuda")
+                else simulator.parameters()
+            )
+            optimizer.load_state_dict(train_state["optimizer_state"])
+            optimizer_to(optimizer, device_id)
+
+            # set global train state
+            step = train_state["global_train_state"]["step"]
+            epoch = train_state["global_train_state"]["epoch"]
+            train_loss_hist = train_state["loss_history"]["train"]
+            valid_loss_hist = train_state["loss_history"]["valid"]
+
+        else:
+            msg = f'Specified model_file {flags["model_path"] + flags["model_file"]} and train_state_file {flags["model_path"] + flags["train_state_file"]} not found.'
+            raise FileNotFoundError(msg)
+
+    simulator.train()
+    simulator.to(device_id)
+
+    # Get data loader
+    get_data_loader = (
+        distribute.get_data_distributed_dataloader_by_samples
+        if device == torch.device("cuda")
+        else data_loader.get_data_loader_by_samples
+    )
+
+    # Load training data
+    dl = get_data_loader(
+        path=f'{flags["data_path"]}train.npz',
+        input_length_sequence=INPUT_SEQUENCE_LENGTH,
+        batch_size=flags["batch_size"],
+    )
+    n_features = len(dl.dataset._data[0])
+
+    # Load validation data
+    if flags["validation_interval"] is not None:
+        dl_valid = get_data_loader(
+            path=f'{flags["data_path"]}valid.npz',
+            input_length_sequence=INPUT_SEQUENCE_LENGTH,
+            batch_size=flags["batch_size"],
+        )
+        if len(dl_valid.dataset._data[0]) != n_features:
+            raise ValueError(
+                f"`n_features` of `valid.npz` and `train.npz` should be the same"
+            )
+
+    print(f"rank = {rank}, cuda = {torch.cuda.is_available()}")
+
+    try:
+        num_epochs = flags["ntraining_steps"] // len(dl) + 1  # Calculate total epochs
+        for epoch in tqdm(range(epoch, num_epochs), desc="Training", unit="epoch"):
+            if device == torch.device("cuda"):
+                torch.distributed.barrier()
+
+            epoch_loss = 0.0
+            steps_this_epoch = 0
+
+            # Create a tqdm progress bar for each epoch
+            with tqdm(total=len(dl), desc=f"Epoch {epoch}", unit="batch") as pbar:
+                for example in dl:
+                    steps_per_epoch += 1
+                    position = example[0][0].to(device_id)
+                    particle_type = example[0][1].to(device_id)
+                    if n_features == 3:
+                        material_property = example[0][2].to(device_id)
+                        n_particles_per_example = example[0][3].to(device_id)
+                    elif n_features == 2:
+                        n_particles_per_example = example[0][2].to(device_id)
+                    else:
+                        raise NotImplementedError
+                    labels = example[1].to(device_id)
+
+                    n_particles_per_example = n_particles_per_example.to(device_id)
+                    labels = labels.to(device_id)
+
+                    sampled_noise = (
+                        noise_utils.get_random_walk_noise_for_position_sequence(
+                            position, noise_std_last_step=flags["noise_std"]
+                        ).to(device_id)
+                    )
+                    non_kinematic_mask = (
+                        (particle_type != KINEMATIC_PARTICLE_ID)
+                        .clone()
+                        .detach()
+                        .to(device_id)
+                    )
+                    sampled_noise *= non_kinematic_mask.view(-1, 1, 1)
+
+                    device_or_rank = rank if device == torch.device("cuda") else device
+                    predict_fn = (
+                        simulator.module.predict_accelerations
+                        if device == torch.device("cuda")
+                        else simulator.predict_accelerations
+                    )
+                    pred_acc, target_acc = predict_fn(
+                        next_positions=labels.to(device_or_rank),
+                        position_sequence_noise=sampled_noise.to(device_or_rank),
+                        position_sequence=position.to(device_or_rank),
+                        nparticles_per_example=n_particles_per_example.to(
+                            device_or_rank
+                        ),
+                        particle_types=particle_type.to(device_or_rank),
+                        material_property=material_property.to(device_or_rank)
+                        if n_features == 3
+                        else None,
+                    )
+
+                    if (
+                        flags["validation_interval"] is not None
+                        and step > 0
+                        and step % flags["validation_interval"] == 0
+                    ):
+                        sampled_valid_example = next(iter(dl_valid))
+                        valid_loss = validation(
+                            simulator,
+                            sampled_valid_example,
+                            n_features,
+                            flags,
+                            rank,
+                            device_id,
+                        )
+                        print(f"Validation loss at {step}: {valid_loss.item()}")
+
+                    loss = acceleration_loss(pred_acc, target_acc, non_kinematic_mask)
+
+                    train_loss = loss.item()
+                    epoch_loss += train_loss
+                    steps_this_epoch += 1
+
+                    optimizer.zero_grad()
+                    loss.backward()
+                    optimizer.step()
+
+                    lr_new = (
+                        flags["lr_init"]
+                        * (flags["lr_decay"] ** (step / flags["lr_decay_steps"]))
+                        * world_size
+                    )
+                    for param in optimizer.param_groups:
+                        param["lr"] = lr_new
+
+                    avg_loss = epoch_loss / steps_this_epoch
+                    pbar.set_postfix(
+                        loss=f"{train_loss:.2f}",
+                        avg_loss=f"{avg_loss:.2f}",
+                        lr=f"{lr_new:.2e}",
+                    )
+                    pbar.update(1)
+
+                    if (rank == 0 or device == torch.device("cpu")) and step % flags[
+                        "nsave_steps"
+                    ] == 0:
+                        save_model_and_train_state(
+                            rank,
+                            device,
+                            simulator,
+                            flags,
+                            step,
+                            epoch,
+                            optimizer,
+                            train_loss,
+                            valid_loss,
+                            train_loss_hist,
+                            valid_loss_hist,
+                        )
+
+                    step += 1
+                    if step >= flags["ntraining_steps"]:
+                        break
+
+            # Epoch level statistics
+            avg_loss = torch.tensor([epoch_loss / steps_this_epoch]).to(device_id)
+            if device == torch.device("cuda"):
+                torch.distributed.reduce(
+                    avg_loss, dst=0, op=torch.distributed.ReduceOp.SUM
+                )
+                avg_loss /= world_size
+
+            train_loss_hist.append((epoch, avg_loss.item()))
+
+            if flags["validation_interval"] is not None:
+                sampled_valid_example = next(iter(dl_valid))
+                epoch_valid_loss = validation(
+                    simulator, sampled_valid_example, n_features, flags, rank, device_id
+                )
+                if device == torch.device("cuda"):
+                    torch.distributed.reduce(
+                        epoch_valid_loss, dst=0, op=torch.distributed.ReduceOp.SUM
+                    )
+                    epoch_valid_loss /= world_size
+                valid_loss_hist.append((epoch, epoch_valid_loss.item()))
+
+            if rank == 0 or device == torch.device("cpu"):
+                print(f"Epoch {epoch}, training loss: {avg_loss.item()}")
+                if flags["validation_interval"] is not None:
+                    print(f"Epoch {epoch}, validation loss: {epoch_valid_loss.item()}")
+
+            if step >= flags["ntraining_steps"]:
+                break
+    except KeyboardInterrupt:
+        pass
+
+    # Save model state on keyboard interrupt
+    save_model_and_train_state(
+        rank,
+        device,
+        simulator,
+        flags,
+        step,
+        epoch,
+        optimizer,
+        train_loss,
+        valid_loss,
+        train_loss_hist,
+        valid_loss_hist,
+    )
+
+    if torch.cuda.is_available():
+        distribute.cleanup()
+
+
+def _get_simulator(
+    metadata: json, acc_noise_std: float, vel_noise_std: float, device: torch.device
+) -> learned_simulator.LearnedSimulator:
+    """Instantiates the simulator.
+
+    Args:
+      metadata: JSON object with metadata.
+      acc_noise_std: Acceleration noise std deviation.
+      vel_noise_std: Velocity noise std deviation.
+      device: PyTorch device 'cpu' or 'cuda'.
+    """
+
+    # Normalization stats
+    normalization_stats = {
+        "acceleration": {
+            "mean": torch.FloatTensor(metadata["acc_mean"]).to(device),
+            "std": torch.sqrt(
+                torch.FloatTensor(metadata["acc_std"]) ** 2 + acc_noise_std**2
+            ).to(device),
+        },
+        "velocity": {
+            "mean": torch.FloatTensor(metadata["vel_mean"]).to(device),
+            "std": torch.sqrt(
+                torch.FloatTensor(metadata["vel_std"]) ** 2 + vel_noise_std**2
+            ).to(device),
+        },
+    }
+
+    # Get necessary parameters for loading simulator.
+    if "nnode_in" in metadata and "nedge_in" in metadata:
+        nnode_in = metadata["nnode_in"]
+        nedge_in = metadata["nedge_in"]
+    else:
+        # Given that there is no additional node feature (e.g., material_property) except for:
+        # (position (dim), velocity (dim*6), particle_type (16)),
+        nnode_in = 37 if metadata["dim"] == 3 else 30
+        nedge_in = metadata["dim"] + 1
+
+    # Init simulator.
+    simulator = learned_simulator.LearnedSimulator(
+        particle_dimensions=metadata["dim"],
+        nnode_in=nnode_in,
+        nedge_in=nedge_in,
+        latent_dim=128,
+        nmessage_passing_steps=10,
+        nmlp_layers=2,
+        mlp_hidden_dim=128,
+        connectivity_radius=metadata["default_connectivity_radius"],
+        boundaries=np.array(metadata["bounds"]),
+        normalization_stats=normalization_stats,
+        nparticle_types=NUM_PARTICLE_TYPES,
+        particle_type_embedding_size=16,
+        boundary_clamp_limit=metadata["boundary_augment"]
+        if "boundary_augment" in metadata
+        else 1.0,
+        device=device,
+    )
+
+    return simulator
+
+
+def validation(simulator, example, n_features, flags, rank, device_id):
+    position = example[0][0].to(device_id)
+    particle_type = example[0][1].to(device_id)
+    if n_features == 3:  # if dl includes material_property
+        material_property = example[0][2].to(device_id)
+        n_particles_per_example = example[0][3].to(device_id)
+    elif n_features == 2:
+        n_particles_per_example = example[0][2].to(device_id)
+    else:
+        raise NotImplementedError
+    labels = example[1].to(device_id)
+
+    # Sample the noise to add to the inputs.
+    sampled_noise = noise_utils.get_random_walk_noise_for_position_sequence(
+        position, noise_std_last_step=flags["noise_std"]
+    ).to(device_id)
+    non_kinematic_mask = (
+        (particle_type != KINEMATIC_PARTICLE_ID).clone().detach().to(device_id)
+    )
+    sampled_noise *= non_kinematic_mask.view(-1, 1, 1)
+
+    # Do evaluation for the validation data
+    device_or_rank = rank if isinstance(device_id, int) else device_id
+    # Select the appropriate prediction function
+    predict_accelerations = (
+        simulator.module.predict_accelerations
+        if isinstance(device_id, int)
+        else simulator.predict_accelerations
+    )
+    # Get the predictions and target accelerations
+    with torch.no_grad():
+        pred_acc, target_acc = predict_accelerations(
             next_positions=labels.to(device_or_rank),
             position_sequence_noise=sampled_noise.to(device_or_rank),
             position_sequence=position.to(device_or_rank),
             nparticles_per_example=n_particles_per_example.to(device_or_rank),
             particle_types=particle_type.to(device_or_rank),
-            material_property=material_property.to(device_or_rank) if n_features == 3 else None
+            material_property=material_property.to(device_or_rank)
+            if n_features == 3
+            else None,
         )
-        
-        # Validation
-        if flags["validation_interval"] is not None:
-          sampled_valid_example = next(iter(dl_valid))
-          if step > 0 and step % flags["validation_interval"] == 0:
-              valid_loss = validation(
-                simulator, sampled_valid_example, n_features, flags, rank, device_id)
-              print(f"Validation loss at {step}: {valid_loss.item()}")
 
-        # Calculate the loss and mask out loss on kinematic particles
-        loss = acceleration_loss(pred_acc, target_acc, non_kinematic_mask)
+    # Compute loss
+    loss = acceleration_loss(pred_acc, target_acc, non_kinematic_mask)
 
-        train_loss = loss.item()
-        epoch_train_loss += train_loss
-
-        # Computes the gradient of loss
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
-
-        # Update learning rate
-        lr_new = flags["lr_init"] * (flags["lr_decay"] ** (step/flags["lr_decay_steps"])) * world_size
-        for param in optimizer.param_groups:
-          param['lr'] = lr_new
-     
-        print(f'rank = {rank}, epoch = {epoch}, step = {step}/{flags["ntraining_steps"]}, loss = {train_loss}', flush=True)
-
-        # Save model state
-        if rank == 0 or device == torch.device("cpu"):
-          if step % flags["nsave_steps"] == 0:
-            save_model_and_train_state(rank, device, simulator, flags, step, epoch, 
-                                       optimizer, train_loss, valid_loss, train_loss_hist, valid_loss_hist)
-
-        step += 1
-        if step >= flags["ntraining_steps"]:
-            break
-
-      # Epoch level statistics
-      # Training loss at epoch
-      epoch_train_loss /= steps_per_epoch
-      epoch_train_loss = torch.tensor([epoch_train_loss]).to(device_id)
-      if device == torch.device("cuda"):
-        torch.distributed.reduce(epoch_train_loss, dst=0, op=torch.distributed.ReduceOp.SUM)
-        epoch_train_loss /= world_size
-
-      train_loss_hist.append((epoch, epoch_train_loss.item()))
-
-      # Validation loss at epoch
-      if flags["validation_interval"] is not None:
-        sampled_valid_example = next(iter(dl_valid))
-        epoch_valid_loss = validation(
-                simulator, sampled_valid_example, n_features, flags, rank, device_id)
-        if device == torch.device("cuda"):
-          torch.distributed.reduce(epoch_valid_loss, dst=0, op=torch.distributed.ReduceOp.SUM)
-          epoch_valid_loss /= world_size
-
-        valid_loss_hist.append((epoch, epoch_valid_loss.item()))
-
-      # Print epoch statistics
-      if rank == 0 or device == torch.device("cpu"):
-        print(f'Epoch {epoch}, training loss: {epoch_train_loss.item()}')
-        if flags["validation_interval"] is not None:
-          print(f'Epoch {epoch}, validation loss: {epoch_valid_loss.item()}')
-      
-      # Reset epoch training loss
-      epoch_train_loss = 0
-      if steps_per_epoch >= len(dl):
-        epoch += 1
-      steps_per_epoch = 0
-      
-      if step >= flags["ntraining_steps"]:
-        break 
-      
-  except KeyboardInterrupt:
-    pass
-
-  # Save model state on keyboard interrupt
-  save_model_and_train_state(rank, device, simulator, flags, step, epoch, optimizer, train_loss, valid_loss, train_loss_hist, valid_loss_hist)
-
-  if torch.cuda.is_available():
-    distribute.cleanup()
-
-
-def _get_simulator(
-        metadata: json,
-        acc_noise_std: float,
-        vel_noise_std: float,
-        device: torch.device) -> learned_simulator.LearnedSimulator:
-  """Instantiates the simulator.
-
-  Args:
-    metadata: JSON object with metadata.
-    acc_noise_std: Acceleration noise std deviation.
-    vel_noise_std: Velocity noise std deviation.
-    device: PyTorch device 'cpu' or 'cuda'.
-  """
-
-  # Normalization stats
-  normalization_stats = {
-      'acceleration': {
-          'mean': torch.FloatTensor(metadata['acc_mean']).to(device),
-          'std': torch.sqrt(torch.FloatTensor(metadata['acc_std'])**2 +
-                            acc_noise_std**2).to(device),
-      },
-      'velocity': {
-          'mean': torch.FloatTensor(metadata['vel_mean']).to(device),
-          'std': torch.sqrt(torch.FloatTensor(metadata['vel_std'])**2 +
-                            vel_noise_std**2).to(device),
-      },
-  }
-
-  # Get necessary parameters for loading simulator.
-  if "nnode_in" in metadata and "nedge_in" in metadata:
-    nnode_in = metadata['nnode_in']
-    nedge_in = metadata['nedge_in']
-  else:
-    # Given that there is no additional node feature (e.g., material_property) except for:
-    # (position (dim), velocity (dim*6), particle_type (16)),
-    nnode_in = 37 if metadata['dim'] == 3 else 30
-    nedge_in = metadata['dim'] + 1
-
-  # Init simulator.
-  simulator = learned_simulator.LearnedSimulator(
-      particle_dimensions=metadata['dim'],
-      nnode_in=nnode_in,
-      nedge_in=nedge_in,
-      latent_dim=128,
-      nmessage_passing_steps=10,
-      nmlp_layers=2,
-      mlp_hidden_dim=128,
-      connectivity_radius=metadata['default_connectivity_radius'],
-      boundaries=np.array(metadata['bounds']),
-      normalization_stats=normalization_stats,
-      nparticle_types=NUM_PARTICLE_TYPES,
-      particle_type_embedding_size=16,
-      boundary_clamp_limit=metadata["boundary_augment"] if "boundary_augment" in metadata else 1.0,
-      device=device)
-
-  return simulator
-
-def validation(
-        simulator,
-        example,
-        n_features,
-        flags,
-        rank,
-        device_id):
-
-  position = example[0][0].to(device_id)
-  particle_type = example[0][1].to(device_id)
-  if n_features == 3:  # if dl includes material_property
-    material_property = example[0][2].to(device_id)
-    n_particles_per_example = example[0][3].to(device_id)
-  elif n_features == 2:
-    n_particles_per_example = example[0][2].to(device_id)
-  else:
-    raise NotImplementedError
-  labels = example[1].to(device_id)
-
-  # Sample the noise to add to the inputs.
-  sampled_noise = noise_utils.get_random_walk_noise_for_position_sequence(
-    position, noise_std_last_step=flags["noise_std"]).to(device_id)
-  non_kinematic_mask = (particle_type != KINEMATIC_PARTICLE_ID).clone().detach().to(device_id)
-  sampled_noise *= non_kinematic_mask.view(-1, 1, 1)
-
-  # Do evaluation for the validation data
-  device_or_rank = rank if isinstance(device_id, int) else device_id
-  # Select the appropriate prediction function
-  predict_accelerations = simulator.module.predict_accelerations if isinstance(device_id, int) else simulator.predict_accelerations
-  # Get the predictions and target accelerations
-  with torch.no_grad():
-      pred_acc, target_acc = predict_accelerations(
-          next_positions=labels.to(device_or_rank),
-          position_sequence_noise=sampled_noise.to(device_or_rank),
-          position_sequence=position.to(device_or_rank),
-          nparticles_per_example=n_particles_per_example.to(device_or_rank),
-          particle_types=particle_type.to(device_or_rank),
-          material_property=material_property.to(device_or_rank) if n_features == 3 else None
-      )
-
-  # Compute loss
-  loss = acceleration_loss(pred_acc, target_acc, non_kinematic_mask)
-
-  return loss
+    return loss
 
 
 def main(_):
-  """Train or evaluates the model.
+    """Train or evaluates the model."""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if device == torch.device("cuda"):
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29500"
 
-  """
-  device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-  if device == torch.device('cuda'):
-    os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = "29500"
+    myflags = reading_utils.flags_to_dict(FLAGS)
 
-  myflags = reading_utils.flags_to_dict(FLAGS)
+    if FLAGS.mode == "train":
+        # If model_path does not exist create new directory.
+        if not os.path.exists(FLAGS.model_path):
+            os.makedirs(FLAGS.model_path)
 
-  if FLAGS.mode == 'train':
-    # If model_path does not exist create new directory.
-    if not os.path.exists(FLAGS.model_path):
-      os.makedirs(FLAGS.model_path)
+        # Train on gpu
+        if device == torch.device("cuda"):
+            available_gpus = torch.cuda.device_count()
+            print(f"Available GPUs = {available_gpus}")
 
-    # Train on gpu 
-    if device == torch.device('cuda'):
-      available_gpus = torch.cuda.device_count()
-      print(f"Available GPUs = {available_gpus}")
+            # Set the number of GPUs based on availability and the specified number
+            if FLAGS.n_gpus is None or FLAGS.n_gpus > available_gpus:
+                world_size = available_gpus
+                if FLAGS.n_gpus is not None:
+                    print(
+                        f"Warning: The number of GPUs specified ({FLAGS.n_gpus}) exceeds the available GPUs ({available_gpus})"
+                    )
+            else:
+                world_size = FLAGS.n_gpus
 
-      # Set the number of GPUs based on availability and the specified number
-      if FLAGS.n_gpus is None or FLAGS.n_gpus > available_gpus:
-        world_size = available_gpus
-        if FLAGS.n_gpus is not None:
-          print(f"Warning: The number of GPUs specified ({FLAGS.n_gpus}) exceeds the available GPUs ({available_gpus})")
-      else:
-        world_size = FLAGS.n_gpus
+            # Print the status of GPU usage
+            print(f"Using {world_size}/{available_gpus} GPUs")
 
-      # Print the status of GPU usage
-      print(f"Using {world_size}/{available_gpus} GPUs")
+            # Spawn training to GPUs
+            distribute.spawn_train(train, myflags, world_size, device)
 
-      # Spawn training to GPUs
-      distribute.spawn_train(train, myflags, world_size, device)
+        # Train on cpu
+        else:
+            rank = None
+            world_size = 1
+            train(rank, myflags, world_size, device)
 
-    # Train on cpu  
-    else:
-      rank = None
-      world_size = 1
-      train(rank, myflags, world_size, device)
-
-  elif FLAGS.mode in ['valid', 'rollout']:
-    # Set device
-    world_size = torch.cuda.device_count()
-    if FLAGS.cuda_device_number is not None and torch.cuda.is_available():
-      device = torch.device(f'cuda:{int(FLAGS.cuda_device_number)}')
-    #test code
-    print(f"device is {device} world size is {world_size}")
-    predict(device)
+    elif FLAGS.mode in ["valid", "rollout"]:
+        # Set device
+        world_size = torch.cuda.device_count()
+        if FLAGS.cuda_device_number is not None and torch.cuda.is_available():
+            device = torch.device(f"cuda:{int(FLAGS.cuda_device_number)}")
+        # test code
+        print(f"device is {device} world size is {world_size}")
+        predict(device)
 
 
-if __name__ == '__main__':
-  app.run(main)
+if __name__ == "__main__":
+    app.run(main)

--- a/gns/train_multinode.py
+++ b/gns/train_multinode.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from absl import flags
 from absl import app
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from gns import learned_simulator
 from gns import noise_utils
 from gns import reading_utils
@@ -26,636 +26,755 @@ from torch.utils import collect_env
 from torch.utils.data.distributed import DistributedSampler
 
 flags.DEFINE_enum(
-    'mode', 'train', ['train', 'valid', 'rollout'],
-    help='Train model, validation or rollout evaluation.')
-flags.DEFINE_integer('batch_size', 2, help='The batch size.')
-flags.DEFINE_float('noise_std', 6.7e-4, help='The std deviation of the noise.')
-flags.DEFINE_string('data_path', None, help='The dataset directory.')
-flags.DEFINE_string('model_path', 'models/', help=('The path for saving checkpoints of the model.'))
-flags.DEFINE_string('output_path', 'rollouts/', help='The path for saving outputs (e.g. rollouts).')
-flags.DEFINE_string('output_filename', 'rollout', help='Base name for saving the rollout')
-flags.DEFINE_string('model_file', None, help=('Model filename (.pt) to resume from. Can also use "latest" to default to newest file.'))
-flags.DEFINE_string('train_state_file', 'train_state.pt', help=('Train state filename (.pt) to resume from. Can also use "latest" to default to newest file.'))
+    "mode",
+    "train",
+    ["train", "valid", "rollout"],
+    help="Train model, validation or rollout evaluation.",
+)
+flags.DEFINE_integer("batch_size", 2, help="The batch size.")
+flags.DEFINE_float("noise_std", 6.7e-4, help="The std deviation of the noise.")
+flags.DEFINE_string("data_path", None, help="The dataset directory.")
+flags.DEFINE_string(
+    "model_path", "models/", help=("The path for saving checkpoints of the model.")
+)
+flags.DEFINE_string(
+    "output_path", "rollouts/", help="The path for saving outputs (e.g. rollouts)."
+)
+flags.DEFINE_string(
+    "output_filename", "rollout", help="Base name for saving the rollout"
+)
+flags.DEFINE_string(
+    "model_file",
+    None,
+    help=(
+        'Model filename (.pt) to resume from. Can also use "latest" to default to newest file.'
+    ),
+)
+flags.DEFINE_string(
+    "train_state_file",
+    "train_state.pt",
+    help=(
+        'Train state filename (.pt) to resume from. Can also use "latest" to default to newest file.'
+    ),
+)
 
-flags.DEFINE_integer('ntraining_steps', int(2E7), help='Number of training steps.')
-flags.DEFINE_integer('nsave_steps', int(5000), help='Number of steps at which to save the model.')
+flags.DEFINE_integer("ntraining_steps", int(2e7), help="Number of training steps.")
+flags.DEFINE_integer(
+    "nsave_steps", int(5000), help="Number of steps at which to save the model."
+)
 
 # Learning rate parameters
-flags.DEFINE_float('lr_init', 1e-4, help='Initial learning rate.')
-flags.DEFINE_float('lr_decay', 0.1, help='Learning rate decay.')
-flags.DEFINE_integer('lr_decay_steps', int(5e6), help='Learning rate decay steps.')
+flags.DEFINE_float("lr_init", 1e-4, help="Initial learning rate.")
+flags.DEFINE_float("lr_decay", 0.1, help="Learning rate decay.")
+flags.DEFINE_integer("lr_decay_steps", int(5e6), help="Learning rate decay steps.")
 
-flags.DEFINE_integer("cuda_device_number", None, help="CUDA device (zero indexed), default is None so default CUDA device will be used.")
+flags.DEFINE_integer(
+    "cuda_device_number",
+    None,
+    help="CUDA device (zero indexed), default is None so default CUDA device will be used.",
+)
 
-#new argument for multinode training
-flags.DEFINE_integer("local-rank", 0, help='local rank for distributed training')
+# new argument for multinode training
+flags.DEFINE_integer("local-rank", 0, help="local rank for distributed training")
 
 FLAGS = flags.FLAGS
 
-if 'LOCAL_RANK' in os.environ:
-  local_rank = int(os.environ['LOCAL_RANK'])
+if "LOCAL_RANK" in os.environ:
+    local_rank = int(os.environ["LOCAL_RANK"])
 
-Stats = collections.namedtuple('Stats', ['mean', 'std'])
+Stats = collections.namedtuple("Stats", ["mean", "std"])
 
 INPUT_SEQUENCE_LENGTH = 6  # So we can calculate the last 5 velocities.
 NUM_PARTICLE_TYPES = 9
 KINEMATIC_PARTICLE_ID = 3
 
+
 def rollout(
-        simulator: learned_simulator.LearnedSimulator,
-        position: torch.tensor,
-        particle_types: torch.tensor,
-        material_property: torch.tensor,
-        n_particles_per_example: torch.tensor,
-        nsteps: int,
-        device: torch.device):
-  """
-  Rolls out a trajectory by applying the model in sequence.
+    simulator: learned_simulator.LearnedSimulator,
+    position: torch.tensor,
+    particle_types: torch.tensor,
+    material_property: torch.tensor,
+    n_particles_per_example: torch.tensor,
+    nsteps: int,
+    device: torch.device,
+):
+    """
+    Rolls out a trajectory by applying the model in sequence.
 
-  Args:
-    simulator: Learned simulator.
-    position: Positions of particles (timesteps, nparticles, ndims)
-    particle_types: Particles types with shape (nparticles)
-    material_property: Friction angle normalized by tan() with shape (nparticles)
-    n_particles_per_example
-    nsteps: Number of steps.
-    device: torch device.
-  """
+    Args:
+      simulator: Learned simulator.
+      position: Positions of particles (timesteps, nparticles, ndims)
+      particle_types: Particles types with shape (nparticles)
+      material_property: Friction angle normalized by tan() with shape (nparticles)
+      n_particles_per_example
+      nsteps: Number of steps.
+      device: torch device.
+    """
 
-  initial_positions = position[:, :INPUT_SEQUENCE_LENGTH]
-  ground_truth_positions = position[:, INPUT_SEQUENCE_LENGTH:]
+    initial_positions = position[:, :INPUT_SEQUENCE_LENGTH]
+    ground_truth_positions = position[:, INPUT_SEQUENCE_LENGTH:]
 
-  current_positions = initial_positions
-  predictions = []
+    current_positions = initial_positions
+    predictions = []
 
-  for step in tqdm(range(nsteps), total=nsteps):
-    # Get next position with shape (nnodes, dim)
-    next_position = simulator.predict_positions(
-        current_positions,
-        nparticles_per_example=[n_particles_per_example],
-        particle_types=particle_types,
-        material_property=material_property
-    )
+    for step in tqdm(range(nsteps), total=nsteps):
+        # Get next position with shape (nnodes, dim)
+        next_position = simulator.predict_positions(
+            current_positions,
+            nparticles_per_example=[n_particles_per_example],
+            particle_types=particle_types,
+            material_property=material_property,
+        )
 
-    # Update kinematic particles from prescribed trajectory.
-    kinematic_mask = (particle_types == KINEMATIC_PARTICLE_ID).clone().detach().to(device)
-    next_position_ground_truth = ground_truth_positions[:, step]
-    kinematic_mask = kinematic_mask.bool()[:, None].expand(-1, current_positions.shape[-1])
-    next_position = torch.where(
-        kinematic_mask, next_position_ground_truth, next_position)
-    predictions.append(next_position)
+        # Update kinematic particles from prescribed trajectory.
+        kinematic_mask = (
+            (particle_types == KINEMATIC_PARTICLE_ID).clone().detach().to(device)
+        )
+        next_position_ground_truth = ground_truth_positions[:, step]
+        kinematic_mask = kinematic_mask.bool()[:, None].expand(
+            -1, current_positions.shape[-1]
+        )
+        next_position = torch.where(
+            kinematic_mask, next_position_ground_truth, next_position
+        )
+        predictions.append(next_position)
 
-    # Shift `current_positions`, removing the oldest position in the sequence
-    # and appending the next position at the end.
-    current_positions = torch.cat(
-        [current_positions[:, 1:], next_position[:, None, :]], dim=1)
+        # Shift `current_positions`, removing the oldest position in the sequence
+        # and appending the next position at the end.
+        current_positions = torch.cat(
+            [current_positions[:, 1:], next_position[:, None, :]], dim=1
+        )
 
-  # Predictions with shape (time, nnodes, dim)
-  predictions = torch.stack(predictions)
-  ground_truth_positions = ground_truth_positions.permute(1, 0, 2)
+    # Predictions with shape (time, nnodes, dim)
+    predictions = torch.stack(predictions)
+    ground_truth_positions = ground_truth_positions.permute(1, 0, 2)
 
-  loss = (predictions - ground_truth_positions) ** 2
+    loss = (predictions - ground_truth_positions) ** 2
 
-  output_dict = {
-      'initial_positions': initial_positions.permute(1, 0, 2).cpu().numpy(),
-      'predicted_rollout': predictions.cpu().numpy(),
-      'ground_truth_rollout': ground_truth_positions.cpu().numpy(),
-      'particle_types': particle_types.cpu().numpy(),
-      'material_property': material_property.cpu().numpy() if material_property is not None else None
-  }
+    output_dict = {
+        "initial_positions": initial_positions.permute(1, 0, 2).cpu().numpy(),
+        "predicted_rollout": predictions.cpu().numpy(),
+        "ground_truth_rollout": ground_truth_positions.cpu().numpy(),
+        "particle_types": particle_types.cpu().numpy(),
+        "material_property": material_property.cpu().numpy()
+        if material_property is not None
+        else None,
+    }
 
-  return output_dict, loss
+    return output_dict, loss
 
 
 def rollout_par(
-        simulator,
-        position: torch.tensor,
-        particle_types: torch.tensor,
-        material_property: torch.tensor,
-        n_particles_per_example: torch.tensor,
-        nsteps: int,
-        device):
-  """
-  Rolls out a trajectory by applying the model in sequence.
+    simulator,
+    position: torch.tensor,
+    particle_types: torch.tensor,
+    material_property: torch.tensor,
+    n_particles_per_example: torch.tensor,
+    nsteps: int,
+    device,
+):
+    """
+    Rolls out a trajectory by applying the model in sequence.
 
-  Args:
-    simulator: Learned simulator.
-    position: Positions of particles (timesteps, nparticles, ndims)
-    particle_types: Particles types with shape (nparticles)
-    material_property: Friction angle normalized by tan() with shape (nparticles)
-    n_particles_per_example
-    nsteps: Number of steps.
-    device: torch device.
-  """
+    Args:
+      simulator: Learned simulator.
+      position: Positions of particles (timesteps, nparticles, ndims)
+      particle_types: Particles types with shape (nparticles)
+      material_property: Friction angle normalized by tan() with shape (nparticles)
+      n_particles_per_example
+      nsteps: Number of steps.
+      device: torch device.
+    """
 
-  initial_positions = position[:, :INPUT_SEQUENCE_LENGTH]
-  ground_truth_positions = position[:, INPUT_SEQUENCE_LENGTH:]
+    initial_positions = position[:, :INPUT_SEQUENCE_LENGTH]
+    ground_truth_positions = position[:, INPUT_SEQUENCE_LENGTH:]
 
-  current_positions = initial_positions
-  predictions = []
+    current_positions = initial_positions
+    predictions = []
 
-  for step in tqdm(range(nsteps), total=nsteps):
-    # Get next position with shape (nnodes, dim)
-    next_position = simulator.module.predict_positions(
-        current_positions,
-        nparticles_per_example=[n_particles_per_example],
-        particle_types=particle_types,
-        material_property=material_property
-    )
+    for step in tqdm(range(nsteps), total=nsteps):
+        # Get next position with shape (nnodes, dim)
+        next_position = simulator.module.predict_positions(
+            current_positions,
+            nparticles_per_example=[n_particles_per_example],
+            particle_types=particle_types,
+            material_property=material_property,
+        )
 
-    # Update kinematic particles from prescribed trajectory.
-    kinematic_mask = (particle_types == KINEMATIC_PARTICLE_ID).clone().detach().to(device)
-    next_position_ground_truth = ground_truth_positions[:, step]
-    kinematic_mask = kinematic_mask.bool()[:, None].expand(-1, current_positions.shape[-1])
-    next_position = torch.where(
-        kinematic_mask, next_position_ground_truth, next_position)
-    predictions.append(next_position)
+        # Update kinematic particles from prescribed trajectory.
+        kinematic_mask = (
+            (particle_types == KINEMATIC_PARTICLE_ID).clone().detach().to(device)
+        )
+        next_position_ground_truth = ground_truth_positions[:, step]
+        kinematic_mask = kinematic_mask.bool()[:, None].expand(
+            -1, current_positions.shape[-1]
+        )
+        next_position = torch.where(
+            kinematic_mask, next_position_ground_truth, next_position
+        )
+        predictions.append(next_position)
 
-    # Shift `current_positions`, removing the oldest position in the sequence
-    # and appending the next position at the end.
-    current_positions = torch.cat(
-        [current_positions[:, 1:], next_position[:, None, :]], dim=1)
+        # Shift `current_positions`, removing the oldest position in the sequence
+        # and appending the next position at the end.
+        current_positions = torch.cat(
+            [current_positions[:, 1:], next_position[:, None, :]], dim=1
+        )
 
-  # Predictions with shape (time, nnodes, dim)
-  predictions = torch.stack(predictions)
-  ground_truth_positions = ground_truth_positions.permute(1, 0, 2)
+    # Predictions with shape (time, nnodes, dim)
+    predictions = torch.stack(predictions)
+    ground_truth_positions = ground_truth_positions.permute(1, 0, 2)
 
-  loss = (predictions - ground_truth_positions) ** 2
+    loss = (predictions - ground_truth_positions) ** 2
 
-  output_dict = {
-      'initial_positions': initial_positions.permute(1, 0, 2).cpu().numpy(),
-      'predicted_rollout': predictions.cpu().numpy(),
-      'ground_truth_rollout': ground_truth_positions.cpu().numpy(),
-      'particle_types': particle_types.cpu().numpy(),
-      'material_property': material_property.cpu().numpy() if material_property is not None else None
-  }
+    output_dict = {
+        "initial_positions": initial_positions.permute(1, 0, 2).cpu().numpy(),
+        "predicted_rollout": predictions.cpu().numpy(),
+        "ground_truth_rollout": ground_truth_positions.cpu().numpy(),
+        "particle_types": particle_types.cpu().numpy(),
+        "material_property": material_property.cpu().numpy()
+        if material_property is not None
+        else None,
+    }
 
-  return output_dict, loss
+    return output_dict, loss
+
 
 def predict(device: str):
-  """Predict rollouts.
+    """Predict rollouts.
 
-  Args:
-    simulator: Trained simulator if not will undergo training.
+    Args:
+      simulator: Trained simulator if not will undergo training.
 
-  """
-  # Read metadata
-  metadata = reading_utils.read_metadata(FLAGS.data_path, "rollout")
-  simulator = _get_simulator(metadata, FLAGS.noise_std, FLAGS.noise_std, device)
+    """
+    # Read metadata
+    metadata = reading_utils.read_metadata(FLAGS.data_path, "rollout")
+    simulator = _get_simulator(metadata, FLAGS.noise_std, FLAGS.noise_std, device)
 
-  # Load simulator
-  if os.path.exists(FLAGS.model_path + FLAGS.model_file):
-    simulator.load(FLAGS.model_path + FLAGS.model_file)
-  else:
-    raise Exception(f"Model does not exist at {FLAGS.model_path + FLAGS.model_file}")
+    # Load simulator
+    if os.path.exists(FLAGS.model_path + FLAGS.model_file):
+        simulator.load(FLAGS.model_path + FLAGS.model_file)
+    else:
+        raise Exception(
+            f"Model does not exist at {FLAGS.model_path + FLAGS.model_file}"
+        )
 
-  simulator.to(device)
-  simulator.eval()
+    simulator.to(device)
+    simulator.eval()
 
-  # Output path
-  if not os.path.exists(FLAGS.output_path):
-    os.makedirs(FLAGS.output_path)
+    # Output path
+    if not os.path.exists(FLAGS.output_path):
+        os.makedirs(FLAGS.output_path)
 
-  # Use `valid`` set for eval mode if not use `test`
-  split = 'test' if FLAGS.mode == 'rollout' else 'valid'
+    # Use `valid`` set for eval mode if not use `test`
+    split = "test" if FLAGS.mode == "rollout" else "valid"
 
-  # Get dataset
-  ds = data_loader.get_data_loader_by_trajectories(path=f"{FLAGS.data_path}{split}.npz")
-  # See if our dataset has material property as feature
-  if len(ds.dataset._data[0]) == 3:  # `ds` has (positions, particle_type, material_property)
-    material_property_as_feature = True
-  elif len(ds.dataset._data[0]) == 2:  # `ds` only has (positions, particle_type)
-    material_property_as_feature = False
-  else:
-    raise NotImplementedError
+    # Get dataset
+    ds = data_loader.get_data_loader_by_trajectories(
+        path=f"{FLAGS.data_path}{split}.npz"
+    )
+    # See if our dataset has material property as feature
+    if (
+        len(ds.dataset._data[0]) == 3
+    ):  # `ds` has (positions, particle_type, material_property)
+        material_property_as_feature = True
+    elif len(ds.dataset._data[0]) == 2:  # `ds` only has (positions, particle_type)
+        material_property_as_feature = False
+    else:
+        raise NotImplementedError
 
-  eval_loss = []
-  with torch.no_grad():
-    torch.distributed.barrier()
-    for example_i, features in enumerate(ds):
-      positions = features[0].to(device)
-      if metadata['sequence_length'] is not None:
-        # If `sequence_length` is predefined in metadata,
-        nsteps = metadata['sequence_length'] - INPUT_SEQUENCE_LENGTH
-      else:
-        # If no predefined `sequence_length`, then get the sequence length
-        sequence_length = positions.shape[1]
-        nsteps = sequence_length - INPUT_SEQUENCE_LENGTH
-      particle_type = features[1].to(device)
-      if material_property_as_feature:
-        material_property = features[2].to(device)
-        n_particles_per_example = torch.tensor([int(features[3])], dtype=torch.int32).to(device)
-      else:
-        material_property = None
-        n_particles_per_example = torch.tensor([int(features[2])], dtype=torch.int32).to(device)
+    eval_loss = []
+    with torch.no_grad():
+        torch.distributed.barrier()
+        for example_i, features in enumerate(ds):
+            positions = features[0].to(device)
+            if metadata["sequence_length"] is not None:
+                # If `sequence_length` is predefined in metadata,
+                nsteps = metadata["sequence_length"] - INPUT_SEQUENCE_LENGTH
+            else:
+                # If no predefined `sequence_length`, then get the sequence length
+                sequence_length = positions.shape[1]
+                nsteps = sequence_length - INPUT_SEQUENCE_LENGTH
+            particle_type = features[1].to(device)
+            if material_property_as_feature:
+                material_property = features[2].to(device)
+                n_particles_per_example = torch.tensor(
+                    [int(features[3])], dtype=torch.int32
+                ).to(device)
+            else:
+                material_property = None
+                n_particles_per_example = torch.tensor(
+                    [int(features[2])], dtype=torch.int32
+                ).to(device)
 
-      # Predict example rollout
-      example_rollout, loss = rollout(simulator,
-                                      positions,
-                                      particle_type,
-                                      material_property,
-                                      n_particles_per_example,
-                                      nsteps,
-                                      device)
+            # Predict example rollout
+            example_rollout, loss = rollout(
+                simulator,
+                positions,
+                particle_type,
+                material_property,
+                n_particles_per_example,
+                nsteps,
+                device,
+            )
 
-      example_rollout['metadata'] = metadata
-      print("Predicting example {} loss: {}".format(example_i, loss.mean()))
-      eval_loss.append(torch.flatten(loss))
+            example_rollout["metadata"] = metadata
+            print("Predicting example {} loss: {}".format(example_i, loss.mean()))
+            eval_loss.append(torch.flatten(loss))
 
-      # Save rollout in testing
-      if FLAGS.mode == 'rollout':
-        example_rollout['metadata'] = metadata
-        example_rollout['loss'] = loss.mean()
-        filename = f'{FLAGS.output_filename}_ex{example_i}.pkl'
-        filename = os.path.join(FLAGS.output_path, filename)
-        with open(filename, 'wb') as f:
-          pickle.dump(example_rollout, f)
+            # Save rollout in testing
+            if FLAGS.mode == "rollout":
+                example_rollout["metadata"] = metadata
+                example_rollout["loss"] = loss.mean()
+                filename = f"{FLAGS.output_filename}_ex{example_i}.pkl"
+                filename = os.path.join(FLAGS.output_path, filename)
+                with open(filename, "wb") as f:
+                    pickle.dump(example_rollout, f)
 
-  print("Mean loss on rollout prediction: {}".format(
-      torch.mean(torch.cat(eval_loss))))
+    print(
+        "Mean loss on rollout prediction: {}".format(torch.mean(torch.cat(eval_loss)))
+    )
+
 
 def predict_par(rank):
-  """Predict rollouts.
+    """Predict rollouts.
 
-  Args:
-    simulator: Trained simulator if not will undergo training.
+    Args:
+      simulator: Trained simulator if not will undergo training.
 
-  """
-  # Read metadata
-  metadata = reading_utils.read_metadata(FLAGS.data_path, "rollout")
-  serial_simulator = _get_simulator(metadata, FLAGS.noise_std, FLAGS.noise_std, rank)
-  serial_simulator = serial_simulator.to('cuda')
-  device_id = rank
-  simulator = DDP(serial_simulator, device_ids=[rank])
+    """
+    # Read metadata
+    metadata = reading_utils.read_metadata(FLAGS.data_path, "rollout")
+    serial_simulator = _get_simulator(metadata, FLAGS.noise_std, FLAGS.noise_std, rank)
+    serial_simulator = serial_simulator.to("cuda")
+    device_id = rank
+    simulator = DDP(serial_simulator, device_ids=[rank])
 
-  # Load simulator
-  if os.path.exists(FLAGS.model_path + FLAGS.model_file):
-    simulator.module.load(FLAGS.model_path + FLAGS.model_file)
-  else:
-    raise Exception(f"Model does not exist at {FLAGS.model_path + FLAGS.model_file}")
+    # Load simulator
+    if os.path.exists(FLAGS.model_path + FLAGS.model_file):
+        simulator.module.load(FLAGS.model_path + FLAGS.model_file)
+    else:
+        raise Exception(
+            f"Model does not exist at {FLAGS.model_path + FLAGS.model_file}"
+        )
 
-  simulator.eval()
+    simulator.eval()
 
-  # Output path
-  if not os.path.exists(FLAGS.output_path):
-    os.makedirs(FLAGS.output_path)
+    # Output path
+    if not os.path.exists(FLAGS.output_path):
+        os.makedirs(FLAGS.output_path)
 
-  # Use `valid`` set for eval mode if not use `test`
-  split = 'test' if FLAGS.mode == 'rollout' else 'valid'
+    # Use `valid`` set for eval mode if not use `test`
+    split = "test" if FLAGS.mode == "rollout" else "valid"
 
-  # Get dataset
-  # ds = data_loader.get_data_loader_by_trajectories(path=f"{FLAGS.data_path}{split}.npz")
-  dataset = data_loader.TrajectoriesDataset(path=f"{FLAGS.data_path}{split}.npz")
-  sampler = DistributedSampler(dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=False)
-  ds = torch.utils.data.DataLoader(dataset=dataset, sampler=sampler, batch_size=None, pin_memory=True)
-  # See if our dataset has material property as feature
-  if len(ds.dataset._data[0]) == 3:  # `ds` has (positions, particle_type, material_property)
-    material_property_as_feature = True
-  elif len(ds.dataset._data[0]) == 2:  # `ds` only has (positions, particle_type)
-    material_property_as_feature = False
-  else:
-    raise NotImplementedError
+    # Get dataset
+    # ds = data_loader.get_data_loader_by_trajectories(path=f"{FLAGS.data_path}{split}.npz")
+    dataset = data_loader.TrajectoriesDataset(path=f"{FLAGS.data_path}{split}.npz")
+    sampler = DistributedSampler(
+        dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=False
+    )
+    ds = torch.utils.data.DataLoader(
+        dataset=dataset, sampler=sampler, batch_size=None, pin_memory=True
+    )
+    # See if our dataset has material property as feature
+    if (
+        len(ds.dataset._data[0]) == 3
+    ):  # `ds` has (positions, particle_type, material_property)
+        material_property_as_feature = True
+    elif len(ds.dataset._data[0]) == 2:  # `ds` only has (positions, particle_type)
+        material_property_as_feature = False
+    else:
+        raise NotImplementedError
 
-  eval_loss = []
-  with torch.no_grad():
-    torch.distributed.barrier()
-    for example_i, features in enumerate(ds):
-      if dist.get_rank() == 0:
-        print(example_i)
-      positions = features[0].to(rank)
-      if metadata['sequence_length'] is not None:
-        # If `sequence_length` is predefined in metadata,
-        nsteps = metadata['sequence_length'] - INPUT_SEQUENCE_LENGTH
-      else:
-        # If no predefined `sequence_length`, then get the sequence length
-        sequence_length = positions.shape[1]
-        nsteps = sequence_length - INPUT_SEQUENCE_LENGTH
-      particle_type = features[1].to(rank)
-      if material_property_as_feature:
-        material_property = features[2].to(rank)
-        n_particles_per_example = torch.tensor([int(features[3])], dtype=torch.int32).to(rank)
-      else:
-        material_property = None
-        n_particles_per_example = torch.tensor([int(features[2])], dtype=torch.int32).to(rank)
+    eval_loss = []
+    with torch.no_grad():
+        torch.distributed.barrier()
+        for example_i, features in enumerate(ds):
+            if dist.get_rank() == 0:
+                print(example_i)
+            positions = features[0].to(rank)
+            if metadata["sequence_length"] is not None:
+                # If `sequence_length` is predefined in metadata,
+                nsteps = metadata["sequence_length"] - INPUT_SEQUENCE_LENGTH
+            else:
+                # If no predefined `sequence_length`, then get the sequence length
+                sequence_length = positions.shape[1]
+                nsteps = sequence_length - INPUT_SEQUENCE_LENGTH
+            particle_type = features[1].to(rank)
+            if material_property_as_feature:
+                material_property = features[2].to(rank)
+                n_particles_per_example = torch.tensor(
+                    [int(features[3])], dtype=torch.int32
+                ).to(rank)
+            else:
+                material_property = None
+                n_particles_per_example = torch.tensor(
+                    [int(features[2])], dtype=torch.int32
+                ).to(rank)
 
-      # Predict example rollout
-      example_rollout, loss = rollout_par(simulator,
-                                      positions,
-                                      particle_type,
-                                      material_property,
-                                      n_particles_per_example,
-                                      nsteps,
-                                      rank)
+            # Predict example rollout
+            example_rollout, loss = rollout_par(
+                simulator,
+                positions,
+                particle_type,
+                material_property,
+                n_particles_per_example,
+                nsteps,
+                rank,
+            )
 
-      example_rollout['metadata'] = metadata
-      print("Predicting example {} loss: {}".format(example_i, loss.mean()))
-      eval_loss.append(torch.flatten(loss))
+            example_rollout["metadata"] = metadata
+            print("Predicting example {} loss: {}".format(example_i, loss.mean()))
+            eval_loss.append(torch.flatten(loss))
 
-      # Save rollout in testing
-      if FLAGS.mode == 'rollout':
-        example_rollout['metadata'] = metadata
-        example_rollout['loss'] = loss.mean()
-        filename = f'{FLAGS.output_filename}_ex{example_i}.pkl'
-        filename = os.path.join(FLAGS.output_path, filename)
-        with open(filename, 'wb') as f:
-          pickle.dump(example_rollout, f)
+            # Save rollout in testing
+            if FLAGS.mode == "rollout":
+                example_rollout["metadata"] = metadata
+                example_rollout["loss"] = loss.mean()
+                filename = f"{FLAGS.output_filename}_ex{example_i}.pkl"
+                filename = os.path.join(FLAGS.output_path, filename)
+                with open(filename, "wb") as f:
+                    pickle.dump(example_rollout, f)
 
-  print("Mean loss on rollout prediction: {}".format(
-      torch.mean(torch.cat(eval_loss))))
+    print(
+        "Mean loss on rollout prediction: {}".format(torch.mean(torch.cat(eval_loss)))
+    )
 
 
 def optimizer_to(optim, device):
-  for param in optim.state.values():
-    # Not sure there are any global tensors in the state dict
-    if isinstance(param, torch.Tensor):
-      param.data = param.data.to(device)
-      if param._grad is not None:
-        param._grad.data = param._grad.data.to(device)
-    elif isinstance(param, dict):
-      for subparam in param.values():
-        if isinstance(subparam, torch.Tensor):
-          subparam.data = subparam.data.to(device)
-          if subparam._grad is not None:
-            subparam._grad.data = subparam._grad.data.to(device)
+    for param in optim.state.values():
+        # Not sure there are any global tensors in the state dict
+        if isinstance(param, torch.Tensor):
+            param.data = param.data.to(device)
+            if param._grad is not None:
+                param._grad.data = param._grad.data.to(device)
+        elif isinstance(param, dict):
+            for subparam in param.values():
+                if isinstance(subparam, torch.Tensor):
+                    subparam.data = subparam.data.to(device)
+                    if subparam._grad is not None:
+                        subparam._grad.data = subparam._grad.data.to(device)
+
 
 def train(rank, flags, world_size, verbose):
-  """Train the model.
+    """Train the model.
 
-  Args:
-    rank: local rank
-    world_size: total number of ranks
-    device: cuda device local rank
-  # """
-  # Read metadata
-  metadata = reading_utils.read_metadata(flags["data_path"], "train")
+    Args:
+      rank: local rank
+      world_size: total number of ranks
+      device: cuda device local rank
+    #"""
+    # Read metadata
+    metadata = reading_utils.read_metadata(flags["data_path"], "train")
 
-  # Get simulator and optimizer
-  serial_simulator = _get_simulator(metadata, flags["noise_std"], flags["noise_std"], rank)
-  serial_simulator = serial_simulator.to('cuda')
-  device_id = rank
-  simulator = DDP(serial_simulator, device_ids=[rank])
-  optimizer = torch.optim.Adam(simulator.parameters(), lr=flags["lr_init"]*world_size)
-  step = 0
+    # Get simulator and optimizer
+    serial_simulator = _get_simulator(
+        metadata, flags["noise_std"], flags["noise_std"], rank
+    )
+    serial_simulator = serial_simulator.to("cuda")
+    device_id = rank
+    simulator = DDP(serial_simulator, device_ids=[rank])
+    optimizer = torch.optim.Adam(
+        simulator.parameters(), lr=flags["lr_init"] * world_size
+    )
+    step = 0
 
-  # If model_path does exist and model_file and train_state_file exist continue training.
-  if flags["model_file"] is not None:
+    # If model_path does exist and model_file and train_state_file exist continue training.
+    if flags["model_file"] is not None:
+        if flags["model_file"] == "latest" and flags["train_state_file"] == "latest":
+            # find the latest model, assumes model and train_state files are in step.
+            fnames = glob.glob(f'{flags["model_path"]}*model*pt')
+            max_model_number = 0
+            expr = re.compile(".*model-(\d+).pt")
+            for fname in fnames:
+                model_num = int(expr.search(fname).groups()[0])
+                if model_num > max_model_number:
+                    max_model_number = model_num
+            # reset names to point to the latest.
+            flags["model_file"] = f"model-{max_model_number}.pt"
+            flags["train_state_file"] = f"train_state-{max_model_number}.pt"
 
-    if flags["model_file"] == "latest" and flags["train_state_file"] == "latest":
-      # find the latest model, assumes model and train_state files are in step.
-      fnames = glob.glob(f'{flags["model_path"]}*model*pt')
-      max_model_number = 0
-      expr = re.compile(".*model-(\d+).pt")
-      for fname in fnames:
-        model_num = int(expr.search(fname).groups()[0])
-        if model_num > max_model_number:
-          max_model_number = model_num
-      # reset names to point to the latest.
-      flags["model_file"] = f"model-{max_model_number}.pt"
-      flags["train_state_file"] = f"train_state-{max_model_number}.pt"
+        if os.path.exists(flags["model_path"] + flags["model_file"]) and os.path.exists(
+            flags["model_path"] + flags["train_state_file"]
+        ):
+            # load model
+            simulator.module.load(flags["model_path"] + flags["model_file"])
 
-    if os.path.exists(flags["model_path"] + flags["model_file"]) and os.path.exists(flags["model_path"] + flags["train_state_file"]):
-      # load model
-      simulator.module.load(flags["model_path"] + flags["model_file"])
+            # load train state
+            train_state = torch.load(flags["model_path"] + flags["train_state_file"])
+            # set optimizer state
+            optimizer = torch.optim.Adam(
+                simulator.module.parameters()
+                if device == torch.device("cuda")
+                else simulator.parameters()
+            )
+            optimizer.load_state_dict(train_state["optimizer_state"])
+            optimizer_to(optimizer, device_id)
+            # set global train state
+            step = train_state["global_train_state"].pop("step")
 
-      # load train state
-      train_state = torch.load(flags["model_path"] + flags["train_state_file"])
-      # set optimizer state
-      optimizer = torch.optim.Adam(
-        simulator.module.parameters() if device == torch.device("cuda") else simulator.parameters())
-      optimizer.load_state_dict(train_state["optimizer_state"])
-      optimizer_to(optimizer, device_id)
-      # set global train state
-      step = train_state["global_train_state"].pop("step")
-
-    else:
-      msg = f'Specified model_file {flags["model_path"] + flags["model_file"]} and train_state_file {flags["model_path"] + flags["train_state_file"]} not found.'
-      raise FileNotFoundError(msg)
-
-  simulator.train()
-  simulator.to(device_id)
-
-  # dl = distribute.get_data_distributed_dataloader_by_samples(path=f'{flags["data_path"]}train.npz',
-  #                                                             input_length_sequence=INPUT_SEQUENCE_LENGTH,
-  #                                                             batch_size=flags["batch_size"])
-  path=f'{flags["data_path"]}train.npz'
-  input_length_sequence=INPUT_SEQUENCE_LENGTH
-  batch_size=flags["batch_size"]
-  dataset = data_loader.SamplesDataset(path, input_length_sequence)
-  # for multi node training we need to use pytorch's distributed sampler, see https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler
-  sampler = DistributedSampler(dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=True)
-  dl = torch.utils.data.DataLoader(dataset=dataset, sampler=sampler, batch_size=batch_size, pin_memory=True, collate_fn=data_loader.collate_fn)
-
- 
-  n_features = len(dl.dataset._data[0])
-
-  not_reached_nsteps = True
-  try:
-    while not_reached_nsteps:
-      torch.distributed.barrier()
-      for example in dl:  # ((position, particle_type, material_property, n_particles_per_example), labels) are in dl
-        position = example[0][0].to(device_id)
-        particle_type = example[0][1].to(device_id)
-        if n_features == 3:  # if dl includes material_property
-          material_property = example[0][2].to(device_id)
-          n_particles_per_example = example[0][3].to(device_id)
-        elif n_features == 2:
-          n_particles_per_example = example[0][2].to(device_id)
         else:
-          raise NotImplementedError
-        labels = example[1].to(device_id)
+            msg = f'Specified model_file {flags["model_path"] + flags["model_file"]} and train_state_file {flags["model_path"] + flags["train_state_file"]} not found.'
+            raise FileNotFoundError(msg)
 
-        n_particles_per_example.to(device_id)
-        labels.to(device_id)
+    simulator.train()
+    simulator.to(device_id)
 
-        # TODO (jpv): Move noise addition to data_loader
-        # Sample the noise to add to the inputs to the model during training.
-        sampled_noise = noise_utils.get_random_walk_noise_for_position_sequence(position, noise_std_last_step=flags["noise_std"]).to(device_id)
-        non_kinematic_mask = (particle_type != KINEMATIC_PARTICLE_ID).clone().detach().to(device_id)
-        sampled_noise *= non_kinematic_mask.view(-1, 1, 1)
+    # dl = distribute.get_data_distributed_dataloader_by_samples(path=f'{flags["data_path"]}train.npz',
+    #                                                             input_length_sequence=INPUT_SEQUENCE_LENGTH,
+    #                                                             batch_size=flags["batch_size"])
+    path = f'{flags["data_path"]}train.npz'
+    input_length_sequence = INPUT_SEQUENCE_LENGTH
+    batch_size = flags["batch_size"]
+    dataset = data_loader.SamplesDataset(path, input_length_sequence)
+    # for multi node training we need to use pytorch's distributed sampler, see https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler
+    sampler = DistributedSampler(
+        dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=True
+    )
+    dl = torch.utils.data.DataLoader(
+        dataset=dataset,
+        sampler=sampler,
+        batch_size=batch_size,
+        pin_memory=True,
+        collate_fn=data_loader.collate_fn,
+    )
 
-        # Get the predictions and target accelerations.
-        pred_acc, target_acc = simulator.module.predict_accelerations(
-          next_positions=labels.to(rank),
-          position_sequence_noise=sampled_noise.to(rank),
-          position_sequence=position.to(rank),
-          nparticles_per_example=n_particles_per_example.to(rank),
-          particle_types=particle_type.to(rank),
-          material_property=material_property.to(rank) if n_features == 3 else None
+    n_features = len(dl.dataset._data[0])
+
+    not_reached_nsteps = True
+    try:
+        while not_reached_nsteps:
+            torch.distributed.barrier()
+            for (
+                example
+            ) in (
+                dl
+            ):  # ((position, particle_type, material_property, n_particles_per_example), labels) are in dl
+                position = example[0][0].to(device_id)
+                particle_type = example[0][1].to(device_id)
+                if n_features == 3:  # if dl includes material_property
+                    material_property = example[0][2].to(device_id)
+                    n_particles_per_example = example[0][3].to(device_id)
+                elif n_features == 2:
+                    n_particles_per_example = example[0][2].to(device_id)
+                else:
+                    raise NotImplementedError
+                labels = example[1].to(device_id)
+
+                n_particles_per_example.to(device_id)
+                labels.to(device_id)
+
+                # TODO (jpv): Move noise addition to data_loader
+                # Sample the noise to add to the inputs to the model during training.
+                sampled_noise = noise_utils.get_random_walk_noise_for_position_sequence(
+                    position, noise_std_last_step=flags["noise_std"]
+                ).to(device_id)
+                non_kinematic_mask = (
+                    (particle_type != KINEMATIC_PARTICLE_ID)
+                    .clone()
+                    .detach()
+                    .to(device_id)
+                )
+                sampled_noise *= non_kinematic_mask.view(-1, 1, 1)
+
+                # Get the predictions and target accelerations.
+                pred_acc, target_acc = simulator.module.predict_accelerations(
+                    next_positions=labels.to(rank),
+                    position_sequence_noise=sampled_noise.to(rank),
+                    position_sequence=position.to(rank),
+                    nparticles_per_example=n_particles_per_example.to(rank),
+                    particle_types=particle_type.to(rank),
+                    material_property=material_property.to(rank)
+                    if n_features == 3
+                    else None,
+                )
+
+                # Calculate the loss and mask out loss on kinematic particles
+                loss = (pred_acc - target_acc) ** 2
+                loss = loss.sum(dim=-1)
+                num_non_kinematic = non_kinematic_mask.sum()
+                loss = torch.where(
+                    non_kinematic_mask.bool(), loss, torch.zeros_like(loss)
+                )
+                loss = loss.sum() / num_non_kinematic
+
+                # Computes the gradient of loss
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+                # Update learning rate
+                lr_new = (
+                    flags["lr_init"]
+                    * (flags["lr_decay"] ** (step / flags["lr_decay_steps"]))
+                    * world_size
+                )
+                for param in optimizer.param_groups:
+                    param["lr"] = lr_new
+
+                # for multi node training we need to use global rank (verbose is true is global rank is 0) instead of local rank to decide whether to print
+                if verbose:
+                    print(
+                        f'Training step: {step}/{flags["ntraining_steps"]}. Loss: {loss}.',
+                        flush=True,
+                    )
+                    # Save model state
+                    if step % flags["nsave_steps"] == 0:
+                        simulator.module.save(
+                            flags["model_path"] + "model-" + str(step) + ".pt"
+                        )
+                        train_state = dict(
+                            optimizer_state=optimizer.state_dict(),
+                            global_train_state={"step": step},
+                            loss=loss.item(),
+                        )
+                        torch.save(
+                            train_state, f'{flags["model_path"]}train_state-{step}.pt'
+                        )
+
+                # Complete training
+                if step >= flags["ntraining_steps"]:
+                    not_reached_nsteps = False
+                    break
+
+                step += 1
+
+    except KeyboardInterrupt:
+        pass
+
+    if rank == 0:
+        simulator.module.save(flags["model_path"] + "model-" + str(step) + ".pt")
+        train_state = dict(
+            optimizer_state=optimizer.state_dict(),
+            global_train_state={"step": step},
+            loss=loss.item(),
         )
-       
-        # Calculate the loss and mask out loss on kinematic particles
-        loss = (pred_acc - target_acc) ** 2
-        loss = loss.sum(dim=-1)
-        num_non_kinematic = non_kinematic_mask.sum()
-        loss = torch.where(non_kinematic_mask.bool(),
-                         loss, torch.zeros_like(loss))
-        loss = loss.sum() / num_non_kinematic
+        torch.save(train_state, f'{flags["model_path"]}train_state-{step}.pt')
 
-        # Computes the gradient of loss
-        optimizer.zero_grad()
-        loss.backward()
-        optimizer.step()
-
-        # Update learning rate
-        lr_new = flags["lr_init"] * (flags["lr_decay"] ** (step/flags["lr_decay_steps"])) * world_size
-        for param in optimizer.param_groups:
-          param['lr'] = lr_new
-
-        # for multi node training we need to use global rank (verbose is true is global rank is 0) instead of local rank to decide whether to print
-        if verbose:
-          print(f'Training step: {step}/{flags["ntraining_steps"]}. Loss: {loss}.',flush=True)
-          # Save model state
-          if step % flags["nsave_steps"] == 0:
-            simulator.module.save(flags["model_path"] + 'model-'+str(step)+'.pt')
-            train_state = dict(optimizer_state=optimizer.state_dict(),
-                               global_train_state={"step": step},
-                               loss=loss.item())
-            torch.save(train_state, f'{flags["model_path"]}train_state-{step}.pt')
-
-        # Complete training
-        if (step >= flags["ntraining_steps"]):
-          not_reached_nsteps = False
-          break
-
-        step += 1
-
-  except KeyboardInterrupt:
-    pass
-
-  if rank == 0:
-    simulator.module.save(flags["model_path"] + 'model-'+str(step)+'.pt')
-    train_state = dict(optimizer_state=optimizer.state_dict(),
-                       global_train_state={"step": step},
-                       loss=loss.item())
-    torch.save(train_state, f'{flags["model_path"]}train_state-{step}.pt')
-
-  if torch.cuda.is_available():
-    torch.distributed.destroy_process_group()
+    if torch.cuda.is_available():
+        torch.distributed.destroy_process_group()
 
 
 def _get_simulator(
-        metadata: json,
-        acc_noise_std: float,
-        vel_noise_std: float,
-        device: torch.device) -> learned_simulator.LearnedSimulator:
-  """Instantiates the simulator.
+    metadata: json, acc_noise_std: float, vel_noise_std: float, device: torch.device
+) -> learned_simulator.LearnedSimulator:
+    """Instantiates the simulator.
 
-  Args:
-    metadata: JSON object with metadata.
-    acc_noise_std: Acceleration noise std deviation.
-    vel_noise_std: Velocity noise std deviation.
-    device: PyTorch device 'cpu' or 'cuda'.
-  """
+    Args:
+      metadata: JSON object with metadata.
+      acc_noise_std: Acceleration noise std deviation.
+      vel_noise_std: Velocity noise std deviation.
+      device: PyTorch device 'cpu' or 'cuda'.
+    """
 
-  # Normalization stats
-  normalization_stats = {
-      'acceleration': {
-          'mean': torch.FloatTensor(metadata['acc_mean']).to(device),
-          'std': torch.sqrt(torch.FloatTensor(metadata['acc_std'])**2 +
-                            acc_noise_std**2).to(device),
-      },
-      'velocity': {
-          'mean': torch.FloatTensor(metadata['vel_mean']).to(device),
-          'std': torch.sqrt(torch.FloatTensor(metadata['vel_std'])**2 +
-                            vel_noise_std**2).to(device),
-      },
-  }
+    # Normalization stats
+    normalization_stats = {
+        "acceleration": {
+            "mean": torch.FloatTensor(metadata["acc_mean"]).to(device),
+            "std": torch.sqrt(
+                torch.FloatTensor(metadata["acc_std"]) ** 2 + acc_noise_std**2
+            ).to(device),
+        },
+        "velocity": {
+            "mean": torch.FloatTensor(metadata["vel_mean"]).to(device),
+            "std": torch.sqrt(
+                torch.FloatTensor(metadata["vel_std"]) ** 2 + vel_noise_std**2
+            ).to(device),
+        },
+    }
 
-  # Get necessary parameters for loading simulator.
-  if "nnode_in" in metadata and "nedge_in" in metadata:
-    nnode_in = metadata['nnode_in']
-    nedge_in = metadata['nedge_in']
-  else:
-    # Given that there is no additional node feature (e.g., material_property) except for:
-    # (position (dim), velocity (dim*6), particle_type (16)),
-    nnode_in = 37 if metadata['dim'] == 3 else 30
-    nedge_in = metadata['dim'] + 1
+    # Get necessary parameters for loading simulator.
+    if "nnode_in" in metadata and "nedge_in" in metadata:
+        nnode_in = metadata["nnode_in"]
+        nedge_in = metadata["nedge_in"]
+    else:
+        # Given that there is no additional node feature (e.g., material_property) except for:
+        # (position (dim), velocity (dim*6), particle_type (16)),
+        nnode_in = 37 if metadata["dim"] == 3 else 30
+        nedge_in = metadata["dim"] + 1
 
-  # Init simulator.
-  simulator = learned_simulator.LearnedSimulator(
-      particle_dimensions=metadata['dim'],
-      nnode_in=nnode_in,
-      nedge_in=nedge_in,
-      latent_dim=128,
-      nmessage_passing_steps=10,
-      nmlp_layers=2,
-      mlp_hidden_dim=128,
-      connectivity_radius=metadata['default_connectivity_radius'],
-      boundaries=np.array(metadata['bounds']),
-      normalization_stats=normalization_stats,
-      nparticle_types=NUM_PARTICLE_TYPES,
-      particle_type_embedding_size=16,
-      boundary_clamp_limit=metadata["boundary_augment"] if "boundary_augment" in metadata else 1.0,
-      device=device)
+    # Init simulator.
+    simulator = learned_simulator.LearnedSimulator(
+        particle_dimensions=metadata["dim"],
+        nnode_in=nnode_in,
+        nedge_in=nedge_in,
+        latent_dim=128,
+        nmessage_passing_steps=10,
+        nmlp_layers=2,
+        mlp_hidden_dim=128,
+        connectivity_radius=metadata["default_connectivity_radius"],
+        boundaries=np.array(metadata["bounds"]),
+        normalization_stats=normalization_stats,
+        nparticle_types=NUM_PARTICLE_TYPES,
+        particle_type_embedding_size=16,
+        boundary_clamp_limit=metadata["boundary_augment"]
+        if "boundary_augment" in metadata
+        else 1.0,
+        device=device,
+    )
 
-  return simulator
+    return simulator
 
 
 def main(_):
-  """Train or evaluates the model.
+    """Train or evaluates the model."""
+    device = torch.device("cuda")
+    myflags = {}
+    myflags["data_path"] = FLAGS.data_path
+    myflags["noise_std"] = FLAGS.noise_std
+    myflags["lr_init"] = FLAGS.lr_init
+    myflags["lr_decay"] = FLAGS.lr_decay
+    myflags["lr_decay_steps"] = FLAGS.lr_decay_steps
+    myflags["batch_size"] = FLAGS.batch_size
+    myflags["ntraining_steps"] = FLAGS.ntraining_steps
+    myflags["nsave_steps"] = FLAGS.nsave_steps
+    myflags["model_file"] = FLAGS.model_file
+    myflags["model_path"] = FLAGS.model_path
+    myflags["train_state_file"] = FLAGS.train_state_file
 
-  """
-  device = torch.device('cuda')
-  myflags = {}
-  myflags["data_path"] = FLAGS.data_path
-  myflags["noise_std"] = FLAGS.noise_std
-  myflags["lr_init"] = FLAGS.lr_init
-  myflags["lr_decay"] = FLAGS.lr_decay
-  myflags["lr_decay_steps"] = FLAGS.lr_decay_steps
-  myflags["batch_size"] = FLAGS.batch_size
-  myflags["ntraining_steps"] = FLAGS.ntraining_steps
-  myflags["nsave_steps"] = FLAGS.nsave_steps
-  myflags["model_file"] = FLAGS.model_file
-  myflags["model_path"] = FLAGS.model_path
-  myflags["train_state_file"] = FLAGS.train_state_file
-
-  torch.multiprocessing.set_start_method('spawn')
-  torch.distributed.init_process_group(
-      backend="nccl",
-      init_method='env://',
-  )
-  torch.distributed.barrier()
-  # instead of torch.cuda.device_count(), we use dist.get_world_size() to get world size
-  world_size = dist.get_world_size()
-
-  torch.cuda.set_device(local_rank)
-  torch.cuda.manual_seed(0)
-
-  # we use global rank to decide the verbose device
-  flags.DEFINE_boolean('verbose', False, 'Verbose.')
-  FLAGS.verbose = dist.get_rank() == 0
-
-  if FLAGS.verbose:
-      print('Collecting env info...')
-      print(collect_env.get_pretty_env_info())
-      print()
-
-  for r in range(torch.distributed.get_world_size()):
-    if r == torch.distributed.get_rank():
-        print(
-            f'Global rank {torch.distributed.get_rank()} initialized: '
-            f'local_rank = {local_rank}, '
-            f'world_size = {torch.distributed.get_world_size()}',
-        )
+    torch.multiprocessing.set_start_method("spawn")
+    torch.distributed.init_process_group(
+        backend="nccl",
+        init_method="env://",
+    )
     torch.distributed.barrier()
+    # instead of torch.cuda.device_count(), we use dist.get_world_size() to get world size
+    world_size = dist.get_world_size()
+
+    torch.cuda.set_device(local_rank)
+    torch.cuda.manual_seed(0)
+
+    # we use global rank to decide the verbose device
+    flags.DEFINE_boolean("verbose", False, "Verbose.")
+    FLAGS.verbose = dist.get_rank() == 0
+
+    if FLAGS.verbose:
+        print("Collecting env info...")
+        print(collect_env.get_pretty_env_info())
+        print()
+
+    for r in range(torch.distributed.get_world_size()):
+        if r == torch.distributed.get_rank():
+            print(
+                f"Global rank {torch.distributed.get_rank()} initialized: "
+                f"local_rank = {local_rank}, "
+                f"world_size = {torch.distributed.get_world_size()}",
+            )
+        torch.distributed.barrier()
+
+    if FLAGS.mode == "train":
+        # If model_path does not exist create new directory.
+        if not os.path.exists(FLAGS.model_path):
+            os.makedirs(FLAGS.model_path)
+        train(local_rank, myflags, world_size, FLAGS.verbose)
+
+    elif FLAGS.mode in ["valid", "rollout"]:
+        # Set device
+        predict_par(local_rank)
+        # world_size = torch.cuda.device_count()
+        # if FLAGS.cuda_device_number is not None and torch.cuda.is_available():
+        #   device = torch.device(f'cuda:{int(FLAGS.cuda_device_number)}')
+        # predict(device)
 
 
-  if FLAGS.mode == 'train':
-    # If model_path does not exist create new directory.
-    if not os.path.exists(FLAGS.model_path):
-      os.makedirs(FLAGS.model_path)
-    train(local_rank, myflags, world_size, FLAGS.verbose)
-    
-
-    
-  elif FLAGS.mode in ['valid', 'rollout']:
-    # Set device
-    predict_par(local_rank)
-    # world_size = torch.cuda.device_count()
-    # if FLAGS.cuda_device_number is not None and torch.cuda.is_available():
-    #   device = torch.device(f'cuda:{int(FLAGS.cuda_device_number)}')
-    # predict(device)
-
-
-if __name__ == '__main__':
-  app.run(main)
+if __name__ == "__main__":
+    app.run(main)

--- a/meshnet/data_loader.py
+++ b/meshnet/data_loader.py
@@ -3,8 +3,8 @@ import numpy as np
 import torch_geometric
 from torch_geometric.data import Data
 
-class SamplesDataset(torch.utils.data.Dataset):
 
+class SamplesDataset(torch.utils.data.Dataset):
     def __init__(self, path, input_length_sequence, dt):
         super().__init__()
         # load dataset stored in npz format.
@@ -12,7 +12,10 @@ class SamplesDataset(torch.utils.data.Dataset):
         # ["pos", "node_type", "velocity", "cells", "pressure"] for all trajectory.
         # whose shapes are (600, 1876, 2), (600, 1876, 1), (600, 1876, 2), (600, 3518, 3), (600, 1876, 1)
         # convert to list of tuples
-        self._data = [dict(trj_info.item()) for trj_info in np.load(path, allow_pickle=True).values()]
+        self._data = [
+            dict(trj_info.item())
+            for trj_info in np.load(path, allow_pickle=True).values()
+        ]
 
         # length of each trajectory in the dataset
         # excluding the input_length_sequence
@@ -20,12 +23,16 @@ class SamplesDataset(torch.utils.data.Dataset):
         self._dimension = self._data[0]["pos"].shape[-1]
         self._input_length_sequence = input_length_sequence
         self._dt = dt
-        self._data_lengths = [x["pos"].shape[0] - input_length_sequence for x in self._data]
+        self._data_lengths = [
+            x["pos"].shape[0] - input_length_sequence for x in self._data
+        ]
         self._length = sum(self._data_lengths)
 
         # pre-compute cumulative lengths
         # to allow fast indexing in __getitem__
-        self._precompute_cumlengths = [sum(self._data_lengths[:x]) for x in range(1, len(self._data_lengths) + 1)]
+        self._precompute_cumlengths = [
+            sum(self._data_lengths[:x]) for x in range(1, len(self._data_lengths) + 1)
+        ]
         self._precompute_cumlengths = np.array(self._precompute_cumlengths, dtype=int)
 
     def __len__(self):
@@ -35,21 +42,35 @@ class SamplesDataset(torch.utils.data.Dataset):
         # Select the trajectory immediately before
         # the one that exceeds the idx
         # (i.e., the one in which idx resides).
-        trajectory_idx = np.searchsorted(self._precompute_cumlengths - 1, idx, side="left")
+        trajectory_idx = np.searchsorted(
+            self._precompute_cumlengths - 1, idx, side="left"
+        )
 
         # Compute index of pick along time-dimension of trajectory.
-        start_of_selected_trajectory = self._precompute_cumlengths[trajectory_idx-1] if trajectory_idx != 0 else 0
+        start_of_selected_trajectory = (
+            self._precompute_cumlengths[trajectory_idx - 1]
+            if trajectory_idx != 0
+            else 0
+        )
         time_idx = self._input_length_sequence + (idx - start_of_selected_trajectory)
 
         # Prepare training data. Assume `input_sequence_length`=1
-        positions = self._data[trajectory_idx]["pos"][time_idx - 1]  # (nnode, dimension)
+        positions = self._data[trajectory_idx]["pos"][
+            time_idx - 1
+        ]  # (nnode, dimension)
         # positions = np.transpose(positions)
         n_node_per_example = positions.shape[0]  # (nnode, )
         node_type = self._data[trajectory_idx]["node_type"][time_idx - 1]  # (nnode, 1)
-        velocity_feature = self._data[trajectory_idx]["velocity"][time_idx - 1]  # (nnode, dimension)
-        velocity_target = self._data[trajectory_idx]["velocity"][time_idx]  # (nnode, dimension)
+        velocity_feature = self._data[trajectory_idx]["velocity"][
+            time_idx - 1
+        ]  # (nnode, dimension)
+        velocity_target = self._data[trajectory_idx]["velocity"][
+            time_idx
+        ]  # (nnode, dimension)
         pressure = self._data[trajectory_idx]["pressure"][time_idx - 1]  # (nnode, 1)
-        cells = self._data[trajectory_idx]["cells"][time_idx - 1]  # (ncells, nnode_per_cell)
+        cells = self._data[trajectory_idx]["cells"][
+            time_idx - 1
+        ]  # (ncells, nnode_per_cell)
         cells = np.transpose(cells, (1, 0))
         time_idx_vector = np.full(positions.shape[0], time_idx - 1)  # (nnode, )
         time_vector = time_idx_vector * self._dt  # (nnodes, )
@@ -57,23 +78,26 @@ class SamplesDataset(torch.utils.data.Dataset):
 
         # aggregate node features
         node_features = torch.hstack(
-            (torch.tensor(node_type).contiguous(),
-             torch.tensor(velocity_feature).to(torch.float32).contiguous(),
-             torch.tensor(pressure).to(torch.float32).contiguous(),
-             torch.tensor(time_vector).to(torch.float32).contiguous())
+            (
+                torch.tensor(node_type).contiguous(),
+                torch.tensor(velocity_feature).to(torch.float32).contiguous(),
+                torch.tensor(pressure).to(torch.float32).contiguous(),
+                torch.tensor(time_vector).to(torch.float32).contiguous(),
+            )
         )
 
         # make graph
-        graph = Data(x=node_features,
-                     face=torch.tensor(cells).type(torch.LongTensor).contiguous(),
-                     y=torch.tensor(velocity_target).to(torch.float32).contiguous(),
-                     pos=torch.tensor(positions).to(torch.float32).contiguous())
+        graph = Data(
+            x=node_features,
+            face=torch.tensor(cells).type(torch.LongTensor).contiguous(),
+            y=torch.tensor(velocity_target).to(torch.float32).contiguous(),
+            pos=torch.tensor(positions).to(torch.float32).contiguous(),
+        )
 
         return graph
 
 
 class TrajectoriesDataset(torch.utils.data.Dataset):
-
     def __init__(self, path):
         super().__init__()
         # load dataset stored in npz format.
@@ -81,7 +105,10 @@ class TrajectoriesDataset(torch.utils.data.Dataset):
         # ["pos", "node_type", "velocity", "cells", "pressure"] for all trajectory.
         # whose shapes are (600, 1876, 2), (600, 1876, 1), (600, 1876, 2), (600, 3518, 3), (600, 1876, 1)
         # convert to list of tuples
-        self._data = [dict(trj_info.item()) for trj_info in np.load(path, allow_pickle=True).values()]
+        self._data = [
+            dict(trj_info.item())
+            for trj_info in np.load(path, allow_pickle=True).values()
+        ]
 
         # length of each trajectory in the dataset
         # excluding the input_length_sequence
@@ -111,11 +138,18 @@ class TrajectoriesDataset(torch.utils.data.Dataset):
 
         return trajectory
 
-def get_data_loader_by_samples(path, input_length_sequence, dt, batch_size, shuffle=True):
+
+def get_data_loader_by_samples(
+    path, input_length_sequence, dt, batch_size, shuffle=True
+):
     dataset = SamplesDataset(path, input_length_sequence, dt)
-    return torch_geometric.loader.DataLoader(dataset, batch_size=batch_size, shuffle=shuffle)
+    return torch_geometric.loader.DataLoader(
+        dataset, batch_size=batch_size, shuffle=shuffle
+    )
+
 
 def get_data_loader_by_trajectories(path):
     dataset = TrajectoriesDataset(path)
-    return torch.utils.data.DataLoader(dataset, batch_size=None, shuffle=False,
-                                       pin_memory=True)
+    return torch.utils.data.DataLoader(
+        dataset, batch_size=None, shuffle=False, pin_memory=True
+    )

--- a/meshnet/noise.py
+++ b/meshnet/noise.py
@@ -5,7 +5,9 @@ from meshnet.utils import NodeType
 def get_velocity_noise(graph, noise_std, device):
     velocity_sequence = graph.x[:, 1:3]
     type = graph.x[:, 0]
-    noise = torch.normal(std=noise_std, mean=0.0, size=velocity_sequence.shape).to(device)
+    noise = torch.normal(std=noise_std, mean=0.0, size=velocity_sequence.shape).to(
+        device
+    )
     mask = type != NodeType.NORMAL
     noise[mask] = 0
     return noise.to(device)

--- a/meshnet/normalization.py
+++ b/meshnet/normalization.py
@@ -1,21 +1,39 @@
 import torch
 import torch.nn as nn
 
+
 class Normalizer(nn.Module):
-    def __init__(self, size, max_accumulations=10**6, std_epsilon=1e-8, name='Normalizer', device='cuda'):
+    def __init__(
+        self,
+        size,
+        max_accumulations=10**6,
+        std_epsilon=1e-8,
+        name="Normalizer",
+        device="cuda",
+    ):
         super(Normalizer, self).__init__()
-        self.name=name
+        self.name = name
         self._max_accumulations = max_accumulations
-        self._std_epsilon = torch.tensor(std_epsilon, dtype=torch.float32, requires_grad=False, device=device)
-        self._acc_count = torch.tensor(0, dtype=torch.float32, requires_grad=False, device=device)
-        self._num_accumulations = torch.tensor(0, dtype=torch.float32, requires_grad=False, device=device)
-        self._acc_sum = torch.zeros((1, size), dtype=torch.float32, requires_grad=False, device=device)
-        self._acc_sum_squared = torch.zeros((1, size), dtype=torch.float32, requires_grad=False, device=device)
+        self._std_epsilon = torch.tensor(
+            std_epsilon, dtype=torch.float32, requires_grad=False, device=device
+        )
+        self._acc_count = torch.tensor(
+            0, dtype=torch.float32, requires_grad=False, device=device
+        )
+        self._num_accumulations = torch.tensor(
+            0, dtype=torch.float32, requires_grad=False, device=device
+        )
+        self._acc_sum = torch.zeros(
+            (1, size), dtype=torch.float32, requires_grad=False, device=device
+        )
+        self._acc_sum_squared = torch.zeros(
+            (1, size), dtype=torch.float32, requires_grad=False, device=device
+        )
 
     def forward(self, batched_data, accumulate=True):
         """Normalizes input data and accumulates statistics."""
         if accumulate:
-        # stop accumulating after a million updates, to prevent accuracy issues
+            # stop accumulating after a million updates, to prevent accuracy issues
             if self._num_accumulations < self._max_accumulations:
                 self._accumulate(batched_data.detach())
         return (batched_data - self._mean()) / self._std_with_epsilon()
@@ -36,23 +54,29 @@ class Normalizer(nn.Module):
         self._num_accumulations += 1
 
     def _mean(self):
-        safe_count = torch.maximum(self._acc_count, torch.tensor(1.0, dtype=torch.float32, device=self._acc_count.device))
+        safe_count = torch.maximum(
+            self._acc_count,
+            torch.tensor(1.0, dtype=torch.float32, device=self._acc_count.device),
+        )
         return self._acc_sum / safe_count
 
     def _std_with_epsilon(self):
-        safe_count = torch.maximum(self._acc_count, torch.tensor(1.0, dtype=torch.float32, device=self._acc_count.device))
-        std = torch.sqrt(self._acc_sum_squared / safe_count - self._mean()**2)
+        safe_count = torch.maximum(
+            self._acc_count,
+            torch.tensor(1.0, dtype=torch.float32, device=self._acc_count.device),
+        )
+        std = torch.sqrt(self._acc_sum_squared / safe_count - self._mean() ** 2)
         return torch.maximum(std, self._std_epsilon)
 
     def get_variable(self):
-        
-        dict = {'_max_accumulations':self._max_accumulations,
-        '_std_epsilon':self._std_epsilon,
-        '_acc_count': self._acc_count,
-        '_num_accumulations':self._num_accumulations,
-        '_acc_sum': self._acc_sum,
-        '_acc_sum_squared':self._acc_sum_squared,
-        'name':self.name
+        dict = {
+            "_max_accumulations": self._max_accumulations,
+            "_std_epsilon": self._std_epsilon,
+            "_acc_count": self._acc_count,
+            "_num_accumulations": self._num_accumulations,
+            "_acc_sum": self._acc_sum,
+            "_acc_sum_squared": self._acc_sum_squared,
+            "name": self.name,
         }
 
         return dict

--- a/meshnet/render.py
+++ b/meshnet/render.py
@@ -13,34 +13,42 @@ flags.DEFINE_string("rollout_name", None, help="Name of rollout `.pkl` file")
 flags.DEFINE_integer("step_stride", 3, help="Stride of steps to skip.")
 FLAGS = flags.FLAGS
 
-def render_gif_animation():
 
+def render_gif_animation():
     rollout_path = f"{FLAGS.rollout_dir}/{FLAGS.rollout_name}.pkl"
     animation_filename = f"{FLAGS.rollout_dir}/{FLAGS.rollout_name}.gif"
 
     # read rollout data
-    with open(rollout_path, 'rb') as f:
+    with open(rollout_path, "rb") as f:
         result = pickle.load(f)
-    ground_truth_vel = np.concatenate((result["initial_velocities"], result["ground_truth_rollout"]))
-    predicted_vel = np.concatenate((result["initial_velocities"], result["predicted_rollout"]))
+    ground_truth_vel = np.concatenate(
+        (result["initial_velocities"], result["ground_truth_rollout"])
+    )
+    predicted_vel = np.concatenate(
+        (result["initial_velocities"], result["predicted_rollout"])
+    )
 
     # compute velocity magnitude
     ground_truth_vel_magnitude = np.linalg.norm(ground_truth_vel, axis=-1)
     predicted_vel_magnitude = np.linalg.norm(predicted_vel, axis=-1)
     velocity_result = {
         "ground_truth": ground_truth_vel_magnitude,
-        "prediction": predicted_vel_magnitude
+        "prediction": predicted_vel_magnitude,
     }
 
     # variables for render
     n_timesteps = len(ground_truth_vel_magnitude)
-    triang = tri.Triangulation(result["node_coords"][0][:, 0], result["node_coords"][0][:, 1])
+    triang = tri.Triangulation(
+        result["node_coords"][0][:, 0], result["node_coords"][0][:, 1]
+    )
 
     # color
     vmin = np.concatenate(
-        (result["predicted_rollout"][0][:, 0], result["ground_truth_rollout"][0][:, 0])).min()
+        (result["predicted_rollout"][0][:, 0], result["ground_truth_rollout"][0][:, 0])
+    ).min()
     vmax = np.concatenate(
-        (result["predicted_rollout"][0][:, 0], result["ground_truth_rollout"][0][:, 0])).max()
+        (result["predicted_rollout"][0][:, 0], result["ground_truth_rollout"][0][:, 0])
+    ).max()
 
     # Init figures
     fig = plt.figure(figsize=(9.75, 3))
@@ -49,26 +57,30 @@ def render_gif_animation():
         print(f"Render step {i}/{n_timesteps}")
 
         fig.clear()
-        grid = ImageGrid(fig, 111,
-                         nrows_ncols=(2, 1),
-                         axes_pad=0.15,
-                         share_all=True,
-                         cbar_location="right",
-                         cbar_mode="single",
-                         cbar_size="1.5%",
-                         cbar_pad=0.15)
+        grid = ImageGrid(
+            fig,
+            111,
+            nrows_ncols=(2, 1),
+            axes_pad=0.15,
+            share_all=True,
+            cbar_location="right",
+            cbar_mode="single",
+            cbar_size="1.5%",
+            cbar_pad=0.15,
+        )
 
         for j, (sim, vel) in enumerate(velocity_result.items()):
-            grid[j].triplot(triang, 'o-', color='k', ms=0.5, lw=0.3)
+            grid[j].triplot(triang, "o-", color="k", ms=0.5, lw=0.3)
             handle = grid[j].tripcolor(triang, vel[i], vmax=vmax, vmin=vmin)
             fig.colorbar(handle, cax=grid.cbar_axes[0])
             grid[j].set_title(sim)
 
     # Creat animation
     ani = animation.FuncAnimation(
-        fig, animate, frames=np.arange(0, n_timesteps, FLAGS.step_stride), interval=20)
+        fig, animate, frames=np.arange(0, n_timesteps, FLAGS.step_stride), interval=20
+    )
 
-    ani.save(f'{animation_filename}', dpi=100, fps=30, writer='imagemagick')
+    ani.save(f"{animation_filename}", dpi=100, fps=30, writer="imagemagick")
     print(f"Animation saved to: {animation_filename}")
 
 
@@ -76,5 +88,5 @@ def main(_):
     render_gif_animation()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(main)

--- a/meshnet/utils.py
+++ b/meshnet/utils.py
@@ -15,7 +15,6 @@ class NodeType(enum.IntEnum):
 
 
 def datas_to_graph(training_example, dt, device):
-
     # features
     node_coords = training_example[0][0].to(device)  # (nnodes, dims)
     node_type = training_example[0][1].to(device)  # (nnodes, 1)
@@ -28,7 +27,9 @@ def datas_to_graph(training_example, dt, device):
     # n_node_per_example = training_example[0][6]
 
     # aggregate node features
-    node_features = torch.hstack((node_type, velocity_feature, pressure, time_vector)).to(device)
+    node_features = torch.hstack(
+        (node_type, velocity_feature, pressure, time_vector)
+    ).to(device)
 
     # target velocity
     velocity_target = training_example[1].to(device)  # (nnodes, dims)
@@ -45,13 +46,13 @@ def decompose_graph(graph):
     # TODO: make it more robust
     x, edge_index, edge_attr, global_attr = None, None, None, None
     for key in graph.keys:
-        if key=="x":
+        if key == "x":
             x = graph.x
-        elif key=="edge_index":
+        elif key == "edge_index":
             edge_index = graph.edge_index
-        elif key=="edge_attr":
+        elif key == "edge_attr":
             edge_attr = graph.edge_attr
-        elif key=="global_attr":
+        elif key == "global_attr":
             global_attr = graph.global_attr
         else:
             pass
@@ -66,23 +67,23 @@ def copy_geometric_data(graph):
     which keys in a given graph.
     """
     node_attr, edge_index, edge_attr, global_attr = decompose_graph(graph)
-    
+
     ret = Data(x=node_attr, edge_index=edge_index, edge_attr=edge_attr)
     ret.global_attr = global_attr
-    
+
     return ret
 
 
 def optimizer_to(optim, device):
-  for param in optim.state.values():
-    # Not sure there are any global tensors in the state dict
-    if isinstance(param, torch.Tensor):
-      param.data = param.data.to(device)
-      if param._grad is not None:
-        param._grad.data = param._grad.data.to(device)
-    elif isinstance(param, dict):
-      for subparam in param.values():
-        if isinstance(subparam, torch.Tensor):
-          subparam.data = subparam.data.to(device)
-          if subparam._grad is not None:
-            subparam._grad.data = subparam._grad.data.to(device)
+    for param in optim.state.values():
+        # Not sure there are any global tensors in the state dict
+        if isinstance(param, torch.Tensor):
+            param.data = param.data.to(device)
+            if param._grad is not None:
+                param._grad.data = param._grad.data.to(device)
+        elif isinstance(param, dict):
+            for subparam in param.values():
+                if isinstance(subparam, torch.Tensor):
+                    subparam.data = subparam.data.to(device)
+                    if subparam._grad is not None:
+                        subparam._grad.data = subparam._grad.data.to(device)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 absl-py
 autopep8
-numpy==1.23.1
+black
 dm-tree
 matplotlib
+numpy==1.23.1
 pyevtk
 pytest
 torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 absl-py
-autopep8
 black
 dm-tree
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ matplotlib
 numpy==1.23.1
 pyevtk
 pytest
+tensorboard
 torch
 torch_geometric
 torch_sparse

--- a/test/test_data_loader.py
+++ b/test/test_data_loader.py
@@ -6,10 +6,11 @@ import shutil
 import sys
 
 # Add parent directory to Python path
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from gns.data_loader import SamplesDataset, TrajectoriesDataset
+
 
 @pytest.fixture
 def temp_dir():
@@ -17,18 +18,19 @@ def temp_dir():
     yield directory
     shutil.rmtree(directory)
 
+
 @pytest.fixture
 def dummy_data(temp_dir):
     # Create a dummy dataset
     dummy_data = [(np.random.rand(10, 3, 2), i % 3) for i in range(5)]
-    
+
     # Create structured array to hold the data
     structured_data = np.empty(len(dummy_data), dtype=object)
     for i, item in enumerate(dummy_data):
         structured_data[i] = item
 
     # Save the data
-    data_path = os.path.join(temp_dir, 'data.npz')
+    data_path = os.path.join(temp_dir, "data.npz")
     np.savez(data_path, gns_data=structured_data)
 
     return data_path, dummy_data
@@ -38,7 +40,9 @@ def test_samples_dataset(dummy_data):
     data_path, _ = dummy_data
     input_length_sequence = 5
     dataset = SamplesDataset(data_path, input_length_sequence)
-    assert len(dataset) == 25  # 5 (trajectories) * (10 (positions) - 5 (input_length_sequence))
+    assert (
+        len(dataset) == 25
+    )  # 5 (trajectories) * (10 (positions) - 5 (input_length_sequence))
     for i in range(len(dataset)):
         ((positions, particle_type, n_particles_per_example), label) = dataset[i]
         assert positions.shape == (3, input_length_sequence, 2)  # Check positions shape

--- a/test/test_graph_network.py
+++ b/test/test_graph_network.py
@@ -4,10 +4,11 @@ import os
 import sys
 
 # Add parent directory to Python path
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from gns.graph_network import EncodeProcessDecode
+
 
 @pytest.fixture
 def model_data():
@@ -34,6 +35,7 @@ def model_data():
     edge_features = torch.rand(batch_size, nparticles, nedge_in_features)
 
     return model, x, edge_index, edge_features, nparticles, nnode_out_features
+
 
 def test_encode_process_decode(model_data):
     model, x, edge_index, edge_features, nparticles, nnode_out_features = model_data

--- a/test/test_learned_simulator.py
+++ b/test/test_learned_simulator.py
@@ -5,10 +5,11 @@ import os
 import sys
 
 # Add parent directory to Python path
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from gns.learned_simulator import LearnedSimulator
+
 
 @pytest.fixture
 def simulator():
@@ -23,8 +24,8 @@ def simulator():
     connectivity_radius = 0.05
     boundaries = np.array([[-1.0, 1.0], [-1.0, 1.0]])
     normalization_stats = {
-        "acceleration": {'mean': 0., 'std': 1.},
-        "velocity": {'mean': 0., 'std': 1.}
+        "acceleration": {"mean": 0.0, "std": 1.0},
+        "velocity": {"mean": 0.0, "std": 1.0},
     }
     nparticle_types = 1
     particle_type_embedding_size = 16
@@ -32,20 +33,37 @@ def simulator():
     device = "cpu"
 
     return LearnedSimulator(
-        particle_dimensions, nnode_in, nedge_in, latent_dim, nmessage_passing_steps,
-        nmlp_layers, mlp_hidden_dim, connectivity_radius, boundaries,
-        normalization_stats, nparticle_types, particle_type_embedding_size, boundary_clamp_limit, device)
+        particle_dimensions,
+        nnode_in,
+        nedge_in,
+        latent_dim,
+        nmessage_passing_steps,
+        nmlp_layers,
+        mlp_hidden_dim,
+        connectivity_radius,
+        boundaries,
+        normalization_stats,
+        nparticle_types,
+        particle_type_embedding_size,
+        boundary_clamp_limit,
+        device,
+    )
 
 
 def test_encoder_preprocessor(simulator):
     """Test for _encoder_preprocessor"""
-    position_sequence = torch.tensor([[[0.0, 0.0], [0.0, 0.1], [0.0, 0.2], [0.0, 0.3], [0.0, 0.4], [0.0, 0.5]],
-                                      [[0.0, 0.0], [0.0, 0.2], [0.0, 0.4], [0.0, 0.6], [0.0, 0.8], [0.0, 1.0]]])
+    position_sequence = torch.tensor(
+        [
+            [[0.0, 0.0], [0.0, 0.1], [0.0, 0.2], [0.0, 0.3], [0.0, 0.4], [0.0, 0.5]],
+            [[0.0, 0.0], [0.0, 0.2], [0.0, 0.4], [0.0, 0.6], [0.0, 0.8], [0.0, 1.0]],
+        ]
+    )
     nparticles_per_example = torch.tensor([2])
     particle_types = torch.tensor([0, 0])
 
     node_features, edge_index, edge_features = simulator._encoder_preprocessor(
-        position_sequence, nparticles_per_example, particle_types)
+        position_sequence, nparticles_per_example, particle_types
+    )
 
     assert node_features.shape == (2, 14)
     assert edge_index.shape == (2, 2)  # one edge between the 2 particles
@@ -56,4 +74,7 @@ def test_encoder_preprocessor(simulator):
     assert set(edge_index[1].tolist()) == set([0, 1])  # receivers
 
     # check the constructed graph has the expected edge
-    assert {tuple(edge_index[:, i].tolist()) for i in range(edge_index.shape[1])} == {(0, 0), (1, 1)}
+    assert {tuple(edge_index[:, i].tolist()) for i in range(edge_index.shape[1])} == {
+        (0, 0),
+        (1, 1),
+    }

--- a/test/test_noise_utils.py
+++ b/test/test_noise_utils.py
@@ -4,20 +4,27 @@ import numpy as np
 import os, sys
 
 # Add parent directory to Python path
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from gns.noise_utils import get_random_walk_noise_for_position_sequence
 from gns.learned_simulator import time_diff
 
-@pytest.mark.parametrize("nparticles, dim, noise_std_last_step", [(10, 2, 0.1), (20, 3, 0.5)])
-def test_get_random_walk_noise_for_position_sequence(nparticles, dim, noise_std_last_step):
+
+@pytest.mark.parametrize(
+    "nparticles, dim, noise_std_last_step", [(10, 2, 0.1), (20, 3, 0.5)]
+)
+def test_get_random_walk_noise_for_position_sequence(
+    nparticles, dim, noise_std_last_step
+):
     position_sequence = torch.randn(nparticles, 6, dim)
     position_sequence_noise = get_random_walk_noise_for_position_sequence(
-        position_sequence, noise_std_last_step)
+        position_sequence, noise_std_last_step
+    )
 
-    assert position_sequence_noise.shape == position_sequence.shape, \
-        "Output tensor has incorrect shape."
+    assert (
+        position_sequence_noise.shape == position_sequence.shape
+    ), "Output tensor has incorrect shape."
 
     velocity_sequence_noise = time_diff(position_sequence_noise)
     # Compute the standard deviation of the noise in the last velocity
@@ -35,5 +42,6 @@ def test_get_random_walk_noise_for_position_sequence(nparticles, dim, noise_std_
     """
 
     # Check that the first position has no noise
-    assert torch.all(position_sequence_noise[:, 0, :] == 0), \
-        "The first position is expected to have no noise."
+    assert torch.all(
+        position_sequence_noise[:, 0, :] == 0
+    ), "The first position is expected to have no noise."

--- a/test/test_pytorch.py
+++ b/test/test_pytorch.py
@@ -1,3 +1,4 @@
 import torch
+
 x = torch.rand(5, 3)
 print(x)

--- a/test/test_pytorch_cuda_gpu.py
+++ b/test/test_pytorch_cuda_gpu.py
@@ -1,5 +1,6 @@
 import torch
+
 print(torch.cuda.is_available())
 
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(device)

--- a/utils/convert_hdf5_to_npz.ipynb
+++ b/utils/convert_hdf5_to_npz.ipynb
@@ -78,7 +78,7 @@
     "    with h5py.File(fname, \"r\") as f:\n",
     "        velocity[:, 0] = f[\"table\"][\"velocity_x\"][:]\n",
     "        velocity[:, 1] = f[\"table\"][\"velocity_y\"][:]\n",
-    "        \n",
+    "\n",
     "        acceleration[:, 0] = f[\"table\"][\"velocity_x\"][:]\n",
     "        acceleration[:, 1] = f[\"table\"][\"velocity_y\"][:]\n",
     "    velocities.append(velocity)\n",
@@ -87,8 +87,12 @@
     "velocities = np.array(velocities)\n",
     "accelerations = np.array(accelerations)\n",
     "\n",
-    "print(f\"Velcocity: mean={np.mean(velocities, axis=(0,1))}, std={np.std(velocities, axis=(0,1))}\")\n",
-    "print(f\"Acceleration: mean={np.mean(accelerations, axis=(0,1))}, std={np.std(accelerations, axis=(0,1))}\")"
+    "print(\n",
+    "    f\"Velcocity: mean={np.mean(velocities, axis=(0,1))}, std={np.std(velocities, axis=(0,1))}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Acceleration: mean={np.mean(accelerations, axis=(0,1))}, std={np.std(accelerations, axis=(0,1))}\"\n",
+    ")"
    ]
   },
   {
@@ -108,19 +112,19 @@
    "source": [
     "%matplotlib qt5\n",
     "\n",
-    "fig, ax = plt.subplots(figsize=(5,5), dpi=150)\n",
+    "fig, ax = plt.subplots(figsize=(5, 5), dpi=150)\n",
     "plt.ion()\n",
     "fig.show()\n",
     "\n",
     "for position in positions:\n",
     "    ax.clear()\n",
     "    ax.scatter(position[:, 0], position[:, 1], s=0.5)\n",
-    "    ax.set_xlim(0., 1.)\n",
-    "    ax.set_ylim(0., 1.)\n",
-    "    plt.pause(.000001)\n",
+    "    ax.set_xlim(0.0, 1.0)\n",
+    "    ax.set_ylim(0.0, 1.0)\n",
+    "    plt.pause(0.000001)\n",
     "    fig.canvas.draw()\n",
     "\n",
-    "plt.close()  "
+    "plt.close()"
    ]
   },
   {
@@ -139,7 +143,10 @@
    "outputs": [],
    "source": [
     "trajectories = {}\n",
-    "trajectories[\"simulation_trajectory_0\"] = (positions, np.full(positions.shape[1], 6, dtype=int))\n",
+    "trajectories[\"simulation_trajectory_0\"] = (\n",
+    "    positions,\n",
+    "    np.full(positions.shape[1], 6, dtype=int),\n",
+    ")\n",
     "np.savez_compressed(\"train_mpm1to1.npz\", **trajectories)"
    ]
   },

--- a/utils/convert_hdf5_to_npz.py
+++ b/utils/convert_hdf5_to_npz.py
@@ -8,11 +8,13 @@ import numpy as np
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Convert hdf5 trajectories to npz.')
-    parser.add_argument('--path', nargs="+", help="Path(s) to hdf5 files to consume.")
-    parser.add_argument('--ndim', default=2, help="Dimension of input data, default is 2 (i.e., 2D).")
-    parser.add_argument('--dt', default=2E-4, help="Time step between position states.")
-    parser.add_argument('--output', help="Name of the output file.")
+    parser = argparse.ArgumentParser(description="Convert hdf5 trajectories to npz.")
+    parser.add_argument("--path", nargs="+", help="Path(s) to hdf5 files to consume.")
+    parser.add_argument(
+        "--ndim", default=2, help="Dimension of input data, default is 2 (i.e., 2D)."
+    )
+    parser.add_argument("--dt", default=2e-4, help="Time step between position states.")
+    parser.add_argument("--output", help="Name of the output file.")
     args = parser.parse_args()
 
     directories = [pathlib.Path(path) for path in args.path]
@@ -26,23 +28,52 @@ if __name__ == "__main__":
     # for velocity and acceleration.
     ndim = int(args.ndim)
     if ndim == 2:
-        running_sum = dict(velocity_x=0, velocity_y=0, acceleration_x=0, acceleration_y=0)
-        running_sumsq = dict(velocity_x=0, velocity_y=0, acceleration_x=0, acceleration_y=0)
-        running_count = dict(velocity_x=0, velocity_y=0, acceleration_x=0, acceleration_y=0)
+        running_sum = dict(
+            velocity_x=0, velocity_y=0, acceleration_x=0, acceleration_y=0
+        )
+        running_sumsq = dict(
+            velocity_x=0, velocity_y=0, acceleration_x=0, acceleration_y=0
+        )
+        running_count = dict(
+            velocity_x=0, velocity_y=0, acceleration_x=0, acceleration_y=0
+        )
     elif ndim == 3:
-        running_sum = dict(velocity_x=0, velocity_y=0, velocity_z=0, acceleration_x=0, acceleration_y=0, acceleration_z=0)
-        running_sumsq = dict(velocity_x=0, velocity_y=0, velocity_z=0, acceleration_x=0, acceleration_y=0, acceleration_z=0)
-        running_count = dict(velocity_x=0, velocity_y=0, velocity_z=0, acceleration_x=0, acceleration_y=0, acceleration_z=0)
+        running_sum = dict(
+            velocity_x=0,
+            velocity_y=0,
+            velocity_z=0,
+            acceleration_x=0,
+            acceleration_y=0,
+            acceleration_z=0,
+        )
+        running_sumsq = dict(
+            velocity_x=0,
+            velocity_y=0,
+            velocity_z=0,
+            acceleration_x=0,
+            acceleration_y=0,
+            acceleration_z=0,
+        )
+        running_count = dict(
+            velocity_x=0,
+            velocity_y=0,
+            velocity_z=0,
+            acceleration_x=0,
+            acceleration_y=0,
+            acceleration_z=0,
+        )
     else:
-        raise NotImplementedError        
+        raise NotImplementedError
 
     trajectories = {}
     for nth_trajectory, directory in enumerate(directories):
         fnames = glob.glob(f"{str(directory)}/*.h5")
         get_fnumber = re.compile(".*\D(\d+).h5")
-        fnumber_and_fname = [(int(get_fnumber.findall(fname)[0]), fname) for fname in fnames]
+        fnumber_and_fname = [
+            (int(get_fnumber.findall(fname)[0]), fname) for fname in fnames
+        ]
         fnumber_and_fname_sorted = sorted(fnumber_and_fname, key=lambda row: row[0])
-        
+
         # get size of trajectory
         with h5py.File(fnames[0], "r") as f:
             (nparticles,) = f["table"]["coord_x"].shape
@@ -63,29 +94,29 @@ if __name__ == "__main__":
         # compute velocities using finite difference
         # assume velocities before zero are equal to zero
         velocities = np.empty_like(positions)
-        velocities[1:] = (positions[1:] - positions[:-1])/dt
+        velocities[1:] = (positions[1:] - positions[:-1]) / dt
         velocities[0] = 0
 
         # compute accelerations finite difference
         # assume accelerations before zero are equal to zero
         accelerations = np.empty_like(velocities)
-        accelerations[1:] = (velocities[1:] - velocities[:-1])/dt
+        accelerations[1:] = (velocities[1:] - velocities[:-1]) / dt
         accelerations[0] = 0
 
         # update variables for on-line mean and standard deviation calculation.
         for key in running_sum:
             if key == "velocity_x":
-                data = velocities[:,:,0]
+                data = velocities[:, :, 0]
             elif key == "velocity_y":
-                data = velocities[:,:,1]
+                data = velocities[:, :, 1]
             elif key == "velocity_z":
-                data = velocities[:,:,2]
+                data = velocities[:, :, 2]
             elif key == "acceleration_x":
-                data = accelerations[:,:,0]
+                data = accelerations[:, :, 0]
             elif key == "acceleration_y":
-                data = accelerations[:,:,1]
+                data = accelerations[:, :, 1]
             elif key == "acceleration_z":
-                data = accelerations[:,:,2]
+                data = accelerations[:, :, 2]
             else:
                 raise KeyError
 
@@ -93,13 +124,19 @@ if __name__ == "__main__":
             running_sumsq[key] += np.sum(data**2)
             running_count[key] += np.size(data)
 
-        trajectories[str(directory)] = (positions, np.full(positions.shape[1], 6, dtype=int))
+        trajectories[str(directory)] = (
+            positions,
+            np.full(positions.shape[1], 6, dtype=int),
+        )
 
     # compute online mean and standard deviation.
     print("Statistis across all trajectories:")
     for key in running_sum:
         mean = running_sum[key] / running_count[key]
-        std = np.sqrt((running_sumsq[key] - running_sum[key]**2/running_count[key]) / (running_count[key] - 1))
+        std = np.sqrt(
+            (running_sumsq[key] - running_sum[key] ** 2 / running_count[key])
+            / (running_count[key] - 1)
+        )
         print(f"  {key}: mean={mean:.4E}, std={std:.4E}")
 
     np.savez_compressed(args.output, **trajectories)


### PR DESCRIPTION
**Describe the PR**
Add logging with tensorboard and progress bar with each epoch

**Related Issues/PRs**
#74 

**Additional context**
Also added formatter to auto format our python files. This shows I touched a lot of files, but it is just formatting. Please only check `train.py` for review.

- [  ] Should we use `npeochs` instead of `nsteps`?

Outputs look like this:
```
rank = None, cuda = False
Epoch 0: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 994/994 [03:44<00:00,  4.42batch/s, avg_loss=0.34, loss=0.06, lr=1.00e-04]
Epoch 1: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 994/994 [03:58<00:00,  4.17batch/s, avg_loss=0.20, loss=0.19, lr=9.99e-05]
Training: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [07:43<00:00, 231.64s/epoch]
```
Loss histories are available in logs via tensorboard. 
<img width="1154" alt="Screenshot 2024-06-24 at 6 06 41 AM" src="https://github.com/geoelements/gns/assets/3963513/cd865488-f96b-4ff6-b6c3-6c0978ae83d0">

Also includes metadata and hyperparameters
