### PR TITLE
fixing statement for ddp and pkl path

### DIFF
--- a/gns/train.py
+++ b/gns/train.py
@@ -202,7 +202,7 @@ def predict(device: str, cfg: DictConfig):
                 example_rollout["loss"] = loss.mean()
                 filename = f"{cfg.output.filename}_ex{example_i}.pkl"
                 filename_render = f"{cfg.output.filename}_ex{example_i}"
-                filename = os.path.join(cfg.output.path, filename_render)
+                filename = os.path.join(cfg.output.path, f"{filename_render}.pkl")
                 with open(filename, "wb") as f:
                     pickle.dump(example_rollout, f)
             if cfg.rendering.mode:
@@ -628,6 +628,7 @@ def train(rank, cfg, world_size, device, verbose, use_dist):
                                 cfg,
                                 rank,
                                 device_id,
+                                use_dist
                             )
                             writer.add_scalar("Loss/valid", valid_loss.item(), step)
 
@@ -698,9 +699,9 @@ def train(rank, cfg, world_size, device, verbose, use_dist):
             if cfg.training.validation_interval is not None:
                 sampled_valid_example = next(iter(valid_dl))
                 epoch_valid_loss = validation(
-                    simulator, sampled_valid_example, n_features, cfg, rank, device_id
+                    simulator, sampled_valid_example, n_features, cfg, rank, device_id, use_dist
                 )
-                if device == torch.device("cuda"):
+                if use_dist:
                     torch.distributed.reduce(
                         epoch_valid_loss, dst=0, op=torch.distributed.ReduceOp.SUM
                     )
@@ -807,7 +808,7 @@ def _get_simulator(
     return simulator
 
 
-def validation(simulator, example, n_features, cfg, rank, device_id):
+def validation(simulator, example, n_features, cfg, rank, device_id, use_dist):
     (
         position,
         particle_type,
@@ -830,7 +831,7 @@ def validation(simulator, example, n_features, cfg, rank, device_id):
     # Select the appropriate prediction function
     predict_accelerations = (
         simulator.module.predict_accelerations
-        if isinstance(device_id, int)
+        if use_dist
         else simulator.predict_accelerations
     )
     # Get the predictions and target accelerations

--- a/gns/train.py
+++ b/gns/train.py
@@ -628,7 +628,7 @@ def train(rank, cfg, world_size, device, verbose, use_dist):
                                 cfg,
                                 rank,
                                 device_id,
-                                use_dist
+                                use_dist,
                             )
                             writer.add_scalar("Loss/valid", valid_loss.item(), step)
 
@@ -699,7 +699,13 @@ def train(rank, cfg, world_size, device, verbose, use_dist):
             if cfg.training.validation_interval is not None:
                 sampled_valid_example = next(iter(valid_dl))
                 epoch_valid_loss = validation(
-                    simulator, sampled_valid_example, n_features, cfg, rank, device_id, use_dist
+                    simulator,
+                    sampled_valid_example,
+                    n_features,
+                    cfg,
+                    rank,
+                    device_id,
+                    use_dist,
                 )
                 if use_dist:
                     torch.distributed.reduce(


### PR DESCRIPTION
## **Description**

This PR fixes two issues in `train.py` that were causing runtime errors:

1. **Saving `.pkl` files**
2. **Running the validation schedule without DDP**

---

## **Related Issues / Fixes**

### **Issue 1 — Incorrect file path when saving `.pkl` files**
- The file path on **line 205** was missing the `.pkl` extension, causing a save error.
- **Lines 203–204** are redundant but kept for now in case they serve another purpose.

### **Issue 2 — Incorrect DDP logic during validation**
- The original condition on **line 833** used:
  ```python
  if isinstance(device_id, int):
  ```
  This evaluates to `True` even when running on a single GPU, causing the code to incorrectly call `simulator.module.predict_accelerations` instead of `simulator.predict_accelerations`.

- I now pass `use_dist` into the `validation(..., use_dist)` call and update the condition to:
  ```python
  if use_dist:
  ```

- A similar fix was applied on **line 703**, replacing:
  ```python
  if device == torch.device("cuda"):
  ```
  with:
  ```python
  if use_dist:
  ```

---

## **Additional Context**

Add any additional notes here if needed.
